### PR TITLE
fix: pass GITHUB_TOKEN to changesets action for PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,5 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `changesets/action@v1` env block in the release workflow
- Without this, the action had no token to authenticate against the GitHub API and failed with _"GitHub Actions is not permitted to create or approve pull requests"_

## Note

If the error persists after this fix, you'll also need to enable **"Allow GitHub Actions to create and approve pull requests"** in: **Repository Settings → Actions → General → Workflow permissions**.

## Test plan
- [ ] Merge this PR to `main`
- [ ] Verify the release workflow runs and the changesets action successfully creates the version bump PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)