### PR TITLE
fix: reformat files field in package.json to satisfy Biome CI

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,7 @@
     "url": "https://github.com/pulgueta/wompi-sdk/issues"
   },
   "homepage": "https://github.com/pulgueta/wompi-sdk",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

- `changesets/action` expanded `"files": ["dist"]` to a multi-line array when it bumped the version in `packages/core/package.json`
- Biome CI enforces single-line format for short arrays, so the format check failed and blocked the publish step
- This PR restores the single-line format so Biome passes and the release workflow can complete

## Test plan

- [ ] Biome CI (`format and lint`) passes
- [ ] Tests pass
- [ ] Release workflow runs and publishes `@pulgueta/wompi@2.0.0` to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)