### PR TITLE
fix: update repo URLs and collapse files array for Biome CI

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "pulgueta/wompi-sdk"
+      "repo": "pulgueta/wompi-node"
     }
   ],
   "commit": false,

--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -6,10 +6,10 @@ runs:
 
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: "pnpm"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,7 @@
     "url": "https://github.com/pulgueta/wompi-node/issues"
   },
   "homepage": "https://github.com/pulgueta/wompi-node",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,13 +11,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pulgueta/wompi-sdk"
+    "url": "https://github.com/pulgueta/wompi-node"
   },
   "bugs": {
-    "url": "https://github.com/pulgueta/wompi-sdk/issues"
+    "url": "https://github.com/pulgueta/wompi-node/issues"
   },
-  "homepage": "https://github.com/pulgueta/wompi-sdk",
-  "files": ["dist"],
+  "homepage": "https://github.com/pulgueta/wompi-node",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,7 @@
     "url": "https://github.com/pulgueta/wompi-sdk/issues"
   },
   "homepage": "https://github.com/pulgueta/wompi-sdk",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Updates `.changeset/config.json` to reference `pulgueta/wompi-node` (was `wompi-sdk`) so changelog links are correct
- Collapses `"files": ["dist"]` back to a single line in `packages/core/package.json` — Biome CI enforces this format and the changeset version bump kept expanding it to multi-line
- Keeps the action version upgrades from the previous commit (`pnpm/action-setup@v6`, `actions/setup-node@v6`, Node 24)

The npm publish was failing with `E422` because provenance verification checked `repository.url` (now fixed to `wompi-node`) and Biome was blocking the release job from reaching the publish step.

## Test plan

- [ ] Biome CI passes
- [ ] Tests pass  
- [ ] Release workflow publishes `@pulgueta/wompi@2.0.0` to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata and configuration references.
  * Upgraded GitHub Actions to newer versions for improved workflow performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pulgueta/wompi-node/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->