### PR TITLE
fix: update repo references to wompi-node and upgrade setup actions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "pulgueta/wompi-sdk"
+      "repo": "pulgueta/wompi-node"
     }
   ],
   "commit": false,

--- a/.github/setup/action.yaml
+++ b/.github/setup/action.yaml
@@ -6,10 +6,10 @@ runs:
 
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: "pnpm"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pulgueta/wompi-sdk"
+    "url": "https://github.com/pulgueta/wompi-node"
   },
   "bugs": {
-    "url": "https://github.com/pulgueta/wompi-sdk/issues"
+    "url": "https://github.com/pulgueta/wompi-node/issues"
   },
-  "homepage": "https://github.com/pulgueta/wompi-sdk",
+  "homepage": "https://github.com/pulgueta/wompi-node",
   "files": ["dist"],
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Three issues were blocking `@pulgueta/wompi@2.0.0` from publishing:

1. **npm E422 provenance error** — `packages/core/package.json` had `repository.url`, `bugs.url`, and `homepage` pointing to `wompi-sdk`; npm's sigstore provenance check requires these to match the actual repository (`wompi-node`)
2. **Changeset changelog links** — `.changeset/config.json` repo slug updated to `wompi-node` so generated changelog links resolve correctly
3. **Action version upgrades** — `pnpm/action-setup` v4→v6, `actions/setup-node` v4→v6 in `.github/setup/action.yaml`

## Test plan

- [ ] Biome CI passes
- [ ] Tests pass
- [ ] Release workflow publishes `@pulgueta/wompi@2.0.0` to npm after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)