### PR TITLE
chore(ci): exclude package.json from Biome formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,7 +35,8 @@
     "include": ["src/**/*.ts", "test/**/*.spec.ts"]
   },
   "files": {
-    "ignoreUnknown": true
+    "ignoreUnknown": true,
+    "ignore": ["**/package.json"]
   },
   "organizeImports": {
     "enabled": false


### PR DESCRIPTION
`changeset version` rewrites `package.json` with multi-line arrays (the `files` field), which Biome's formatter rejects. This has blocked the release pipeline on every changeset version bump (the #10 and #15 Release runs both failed at the format job for this exact reason, and so did the 3.0.0 publish run).

Excluding `package.json` from Biome (`files.ignore`) — its formatting is owned by changesets/npm/pnpm — lets `pnpm exec biome ci .` pass after a version bump, unblocking `changeset publish`.

Verified locally: `pnpm exec biome ci .` → clean (93 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)