### PR TITLE
feat: BRE-B dispersions (Pagos a Terceros payouts API)

### DIFF
--- a/.changeset/breb-dispersals.md
+++ b/.changeset/breb-dispersals.md
@@ -1,0 +1,5 @@
+---
+"@pulgueta/wompi": minor
+---
+
+Add BRE-B dispersals through `wompi.breb`, including payouts credentials, key resolution, batch creation and queries, paginated transaction records, and typed payout webhook guards. Verify the payouts event envelope with `verifyWebhookEvent(payload, { eventsKey, api: "payouts" })` while payment webhook types remain unchanged.

--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -37,11 +37,16 @@ export default defineConfig({
           "/docs/payment-sources",
           "/docs/payment-links",
           "/docs/pse",
+          "/docs/breb",
         ],
       },
       {
         label: "Examples",
-        items: ["/docs/examples/card-checkout", "/docs/examples/payment-link"],
+        items: [
+          "/docs/examples/card-checkout",
+          "/docs/examples/payment-link",
+          "/docs/examples/breb-payout",
+        ],
       },
       {
         label: "Reference",

--- a/apps/docs/content/docs/breb.mdx
+++ b/apps/docs/content/docs/breb.mdx
@@ -1,0 +1,179 @@
+---
+title: BRE-B dispersals
+description: Resolve BRE-B keys and send payouts through Wompi's Pagos a Terceros API.
+sidebar:
+  label: BRE-B dispersals
+---
+
+BRE-B is Colombia's instant-transfer rail: beneficiaries register a key (email, phone, alphanumeric alias, legal id, or establishment code) with their bank, and you pay them with just that key — no bank, account type, or account number needed.
+
+The `wompi.breb` namespace talks to the **payouts API** (`api.payouts.wompi.co/v2`), which is a different host and credential pair than the payments API. Get the credentials from the Wompi dashboard under **Desarrollo → Programadores → Pagos a Terceros** and pass them as `payouts` in the client options:
+
+```ts
+import { WompiClient } from "@pulgueta/wompi";
+
+const wompi = new WompiClient({
+  publicKey: process.env.WOMPI_PUBLIC_KEY!,
+  payouts: {
+    apiKey: process.env.WOMPI_PAYOUTS_API_KEY!,
+    userPrincipalId: process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID!,
+  },
+  sandbox: true, // uses api.sandbox.payouts.wompi.co
+});
+```
+
+Calling any `breb` method without `payouts` credentials resolves to a `WompiError` — the tuple pattern, never a throw.
+
+## resolveKey(keyValue, keyType?)
+
+Resolves a BRE-B key to its (masked) holder before you pay. Read-only: nothing moves. Show the result to your user and ask them to confirm the beneficiary — this is Wompi's recommended first step and it materially reduces failed payouts.
+
+```ts
+const [error, holder] = await wompi.breb.resolveKey(
+  "@JUANPEREZ",
+  "ALPHANUMERIC",
+);
+if (error) throw error;
+
+holder.holderName; // "JUA*** PER*** GAR***"
+holder.financialEntity?.name; // "BANCOLOMBIA"
+holder.keyType; // "ALPHANUMERIC"
+holder.keyValue; // "@JUA***"
+```
+
+`keyType` is optional — Wompi infers it from the format — but sending it avoids ambiguity (a 10-digit number could be a phone or a legal id).
+
+| `keyType`            | Format                        | Example          |
+| -------------------- | ----------------------------- | ---------------- |
+| `ALPHANUMERIC`       | `@` + 5–20 alphanumeric chars | `@JUANPEREZ`     |
+| `MAIL`               | Valid email                   | `juan@email.com` |
+| `PHONE`              | 10 digits, starts with 3      | `3001234567`     |
+| `IDENTIFICATION`     | 1–18 alphanumeric chars       | `1234567890`     |
+| `ESTABLISHMENT_CODE` | 8 digits                      | `12345678`       |
+
+An unknown or inactive key resolves to a `WompiRequestError` with `statusCode: 404`; the payouts error body (with `code: "EXC_034"`) is on `error.body`.
+
+## createPayout(input, idempotencyKey)
+
+Creates a payout batch. A BRE-B transaction sends `key` instead of `bankId` + `accountType` + `accountNumber`; `legalIdType` + `legalId` remain optional as a pair for BRE-B and are required for a bank transaction. Both destination methods can be mixed in one batch, but not within one transaction.
+
+```ts
+const [error, result] = await wompi.breb.createPayout(
+  {
+    reference: "payout-breb-001",
+    accountId: sourceAccountId, // from GET /accounts in the payouts dashboard/API
+    paymentType: "PROVIDERS", // "PAYROLL" | "PROVIDERS" | "OTHER"
+    transactions: [
+      {
+        amount: 150_000, // in COP cents
+        name: "Juan Perez",
+        email: "juan@example.com",
+        key: "@JUANPEREZ",
+      },
+    ],
+  },
+  `payout-${orderId}`, // idempotency key: unique, 1-64 chars, [a-zA-Z0-9-]
+);
+if (error) throw error;
+
+result.payoutId; // persist this — it identifies the batch
+result.success; // transactions accepted for processing
+result.failed; // transactions rejected by validation
+```
+
+:::warning[Idempotency]
+Every request needs an `idempotencyKey` (letters, numbers, and hyphens; max 64 chars). Reusing one within Wompi's 24-hour window resolves to a `WompiRequestError` with `statusCode: 409` and `code: "EXC_032"` in `error.body`. Derive it from a stable business id and persist the resulting `payoutId`; before retrying outside that window, reconcile the existing payout so you do not create a second one.
+:::
+
+Optional batch fields:
+
+- `dispersionDatetime` (`YYYY-MM-DDTHH:mm`) schedules the payout — must be at least the next day.
+- `recurring` (`{ interval: "biweek" | "month", months: 3 | 6 | 12, description? }`) makes a scheduled payout recur and requires `dispersionDatetime`.
+- `transactionStatus` (`"APPROVED" | "FAILED"`) — **sandbox only** — simulates the final status of every transaction in the batch. Defaults to approved.
+
+## getPayout(payoutId)
+
+Reads the batch — your alternative (or complement) to webhook events.
+
+```ts
+const [error, payout] = await wompi.breb.getPayout(payoutId);
+
+payout.status;
+// "PENDING" | "TOTAL_PAYMENT" | "PARTIAL_PAYMENT" | "REJECTED"
+// with the approval flow enabled: "PENDING_APPROVAL" | "NOT_APPROVED"
+// under anti-fraud review: "AFE_ON_HOLD" | "AFE_REJECTED"
+```
+
+## getPayoutTransactions(payoutId, options?)
+
+Returns Wompi's page metadata and the individual transactions in `records`. Pass positive integer `options.limit` and `options.page` values and continue while `page < pages`.
+
+```ts
+const [error, page] = await wompi.breb.getPayoutTransactions(payoutId, {
+  limit: 50,
+  page: 1,
+});
+
+for (const tx of page?.records ?? []) {
+  tx.status; // "PENDING" | "PROCESSING" | "APPROVED" | "FAILED" | "REJECTED" | "CANCELLED" | ...
+  tx.payeeInfo?.key ?? tx.payee?.key; // query and webhook-style payee fields
+  const failure =
+    typeof tx.failureReason === "string"
+      ? tx.failureReason
+      : tx.failureReason?.description;
+}
+
+page?.page;
+page?.pages;
+```
+
+## Webhook events
+
+Payout results arrive on the same events URL as your other Wompi webhooks (configured per environment in the dashboard's Pagos a Terceros section). Two event types matter — `transaction.updated` per transaction and `payout.updated` per batch — and `verifyWebhookEvent` authenticates both exactly like payment events:
+
+```ts
+import {
+  verifyWebhookEvent,
+  isPayoutTransactionUpdatedEvent,
+  isPayoutUpdatedEvent,
+} from "@pulgueta/wompi/server";
+
+const [error, event] = await verifyWebhookEvent(await request.text(), {
+  eventsKey: process.env.WOMPI_PAYOUTS_EVENTS_KEY!,
+  api: "payouts",
+});
+if (error) return new Response("Invalid signature", { status: 403 });
+
+if (isPayoutTransactionUpdatedEvent(event)) {
+  // One dispersal settled or failed.
+  event.data.transaction.payoutId;
+  event.data.transaction.status; // "APPROVED" | "FAILED" | ...
+  const reason = event.data.transaction.failureReason;
+  const code = typeof reason === "string" ? undefined : reason?.code; // e.g. "C02"
+}
+
+if (isPayoutUpdatedEvent(event)) {
+  // The whole batch changed status.
+  event.data.payout.status; // "TOTAL_PAYMENT" | "PARTIAL_PAYMENT" | ...
+}
+```
+
+:::note[Same name, different payload]
+The payouts API also names its per-transaction event `transaction.updated`, but its envelope differs from a payment event (camelCase `sentAt` and no `environment`). Pass `api: "payouts"` to select that envelope and the payouts events key. The default verifier remains strict for payment events, so existing payment webhook handlers still require `environment`.
+:::
+
+## Sandbox
+
+Point the client at the sandbox with `sandbox: true` and use the sandbox payouts credentials. Only the documented test keys resolve — any other key returns `EXC_034`:
+
+| Key                 | Type             | Simulates                |
+| ------------------- | ---------------- | ------------------------ |
+| `@elias123`         | `ALPHANUMERIC`   | Successful resolution    |
+| `ecolon@wompi.com`  | `MAIL`           | Successful resolution    |
+| `3001234567`        | `PHONE`          | Successful resolution    |
+| `1020304050`        | `IDENTIFICATION` | Successful resolution    |
+| `noexiste@test.com` | `MAIL`           | 404 — key not found      |
+| `inactiva@test.com` | `MAIL`           | 400 — key inactive       |
+| `timeout@test.com`  | `MAIL`           | 503 — resolution timeout |
+
+See the [BRE-B payout example](/docs/examples/breb-payout) for the full resolve → confirm → pay → webhook flow.

--- a/apps/docs/content/docs/examples/breb-payout.mdx
+++ b/apps/docs/content/docs/examples/breb-payout.mdx
@@ -1,0 +1,141 @@
+---
+title: BRE-B payout
+description: Resolve a BRE-B key, confirm the beneficiary, create the dispersal, and settle it from the webhook.
+sidebar:
+  label: BRE-B payout
+---
+
+The full dispersal flow Wompi recommends: resolve the key so your user confirms the beneficiary, create the payout with an idempotency key derived from your own business id, and mark it paid when the webhook lands. Run it against the sandbox first — the same code works in production by swapping credentials and `sandbox: false`.
+
+## 1. Preview the beneficiary
+
+The customer types a key; you resolve it and show the masked holder back for confirmation. No money moves here.
+
+```ts title="src/pages/api/breb/resolve.ts"
+import type { APIRoute } from "astro";
+import { WompiClient } from "@pulgueta/wompi";
+
+export const prerender = false;
+
+const wompi = new WompiClient({
+  publicKey: process.env.WOMPI_PUBLIC_KEY!,
+  payouts: {
+    apiKey: process.env.WOMPI_PAYOUTS_API_KEY!,
+    userPrincipalId: process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID!,
+  },
+  sandbox: true,
+});
+
+export const POST: APIRoute = async ({ request }) => {
+  const { keyValue, keyType } = await request.json();
+
+  const [error, holder] = await wompi.breb.resolveKey(keyValue, keyType);
+
+  if (error) {
+    // EXC_034 (not registered) and EXC_033 (bad format) both land here.
+    return Response.json({ error: error.message }, { status: 422 });
+  }
+
+  // Render this and ask the user: "Is this who you want to pay?"
+  return Response.json({
+    holderName: holder.holderName, // "Eli*** Can*** Mor***"
+    bank: holder.financialEntity?.name, // "BANCO DAVIVIENDA"
+  });
+};
+```
+
+In sandbox, `@elias123` (type `ALPHANUMERIC`) resolves successfully; `noexiste@test.com` simulates a 404.
+
+## 2. Create the dispersal
+
+Only after the user confirms. Derive the idempotency key from your own order id so Wompi rejects duplicate submissions during its 24-hour window. Persist the resulting `payoutId` and reconcile it before retrying outside that window.
+
+```ts title="src/pages/api/breb/payout.ts"
+export const POST: APIRoute = async ({ request }) => {
+  const { orderId, keyValue, name, email, amountInCents } =
+    await request.json();
+
+  const [error, result] = await wompi.breb.createPayout(
+    {
+      reference: `order-${orderId}`,
+      accountId: process.env.WOMPI_PAYOUTS_ACCOUNT_ID!, // your funded source account
+      paymentType: "PROVIDERS",
+      transactions: [{ amount: amountInCents, name, email, key: keyValue }],
+    },
+    `payout-${orderId}`, // idempotency key: 1-64 chars, [a-zA-Z0-9-]
+  );
+
+  if (error) return Response.json({ error: error.message }, { status: 422 });
+
+  // Persist payoutId with status "PENDING"; the webhook settles it.
+  return Response.json({ payoutId: result.payoutId });
+};
+```
+
+:::tip[Simulating failures in sandbox]
+Add `transactionStatus: "FAILED"` to the batch body to make the sandbox fail every transaction, so you can exercise your `FAILED` handling end to end.
+:::
+
+## 3. Settle from the webhook
+
+Wompi POSTs `transaction.updated` (per dispersal) and `payout.updated` (per batch) to the events URL configured under Pagos a Terceros. Verify the signature exactly like payment events, then narrow with the payout guards.
+
+```ts title="src/pages/api/breb/events.ts"
+import type { APIRoute } from "astro";
+import {
+  verifyWebhookEvent,
+  isPayoutTransactionUpdatedEvent,
+  isPayoutUpdatedEvent,
+} from "@pulgueta/wompi/server";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const [error, event] = await verifyWebhookEvent(await request.text(), {
+    eventsKey: process.env.WOMPI_PAYOUTS_EVENTS_KEY!,
+    api: "payouts",
+  });
+  if (error) return new Response("Invalid signature", { status: 403 });
+
+  if (isPayoutTransactionUpdatedEvent(event)) {
+    const tx = event.data.transaction;
+
+    if (tx.status === "APPROVED") {
+      // markPaid(tx.payoutId, tx.id);
+    } else if (tx.status === "FAILED") {
+      const reason =
+        typeof tx.failureReason === "string"
+          ? tx.failureReason
+          : tx.failureReason?.description;
+      // markFailed(tx.payoutId, tx.id, reason);
+    }
+  }
+
+  if (isPayoutUpdatedEvent(event)) {
+    // The batch changed status: "TOTAL_PAYMENT", "PARTIAL_PAYMENT", "REJECTED" —
+    // or "PENDING_APPROVAL" / "NOT_APPROVED" when the approval flow is enabled.
+    // reconcileBatch(event.data.payout.id, event.data.payout.status);
+  }
+
+  // Always 2xx fast — Wompi retries up to 3 more times otherwise.
+  return new Response("OK", { status: 200 });
+};
+```
+
+## 4. Reconcile without webhooks
+
+If events can't reach you (or as a safety net), poll the batch:
+
+```ts
+const [error, payout] = await wompi.breb.getPayout(payoutId);
+
+if (payout?.status === "PARTIAL_PAYMENT") {
+  // Find out which transactions failed and why.
+  const [, page] = await wompi.breb.getPayoutTransactions(payoutId);
+  const failed = page?.records.filter((tx) => tx.status === "FAILED") ?? [];
+}
+```
+
+:::warning[Go-live checklist]
+Before switching `sandbox: false`: production payouts credentials in place, beneficiary confirmation step in the UI, idempotency keys derived from stable business ids, webhook URL configured for production, and amounts verified to be in **cents**.
+:::

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -153,14 +153,17 @@ const signature = await getSignatureKey({
 | `wompi.paymentSources` | `getPaymentSource(id)`, `createPaymentSource(input)`                                                        |
 | `wompi.paymentLinks`   | `getPaymentLink(id)`, `createPaymentLink(input)`, `updatePaymentLink(id, input)`                            |
 | `wompi.pse`            | `getFinancialInstitutions()`                                                                                |
+| `wompi.breb`           | `resolveKey(keyValue, keyType?)`, `createPayout(input, idempotencyKey)`, `getPayout(id)`, `getPayoutTransactions(id, options?)` |
 
 `listTransactions`, `voidTransaction`, and every `paymentSources` / `paymentLinks`
-write requires a `privateKey`.
+write requires a `privateKey`. The `breb` namespace (BRE-B dispersals over the
+Pagos a Terceros API) requires its own credentials, passed as
+`payouts: { apiKey, userPrincipalId }` in the client options.
 
 ### Subpath exports
 
 | Import                    | Contents                                                       |
 | ------------------------- | -------------------------------------------------------------- |
 | `@pulgueta/wompi`         | `WompiClient`                                                  |
-| `@pulgueta/wompi/server`  | `getSignatureKey`, `GetSignatureKeyOptions`                   |
+| `@pulgueta/wompi/server`  | `getSignatureKey`, `GetSignatureKeyOptions`, `verifyWebhookEvent`, webhook event guards |
 | `@pulgueta/wompi/schemas` | Zod schemas, inferred types, `WompiError` and its subclasses, `Result` |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "vitest",
-    "test:cov": "vitest run --coverage"
+    "test": "vitest --typecheck",
+    "test:cov": "vitest run --typecheck --coverage"
   },
   "keywords": [
     "wompi",

--- a/packages/core/src/client/breb/index.ts
+++ b/packages/core/src/client/breb/index.ts
@@ -1,0 +1,172 @@
+import { WompiRequest } from "@/request";
+import {
+  BrebKeyResolutionSchema,
+  BrebKeyTypeSchema,
+  CreatePayoutInputSchema,
+  CreatePayoutResultSchema,
+  PayoutSchema,
+  PayoutTransactionPageSchema,
+  WompiError,
+  wompiResponse,
+} from "@/schemas";
+import type {
+  BrebKeyResolution,
+  CreatePayoutResult,
+  Payout,
+  PayoutTransactionPage,
+  PayoutsCredentials,
+  Result,
+} from "@/schemas";
+
+const KeyResolutionResponseSchema = wompiResponse(BrebKeyResolutionSchema);
+const CreatePayoutResponseSchema = wompiResponse(CreatePayoutResultSchema);
+const PayoutResponseSchema = wompiResponse(PayoutSchema);
+const PayoutTransactionsResponseSchema = wompiResponse(PayoutTransactionPageSchema);
+
+/** Wompi requires 1-64 characters: letters, numbers, and hyphens only. */
+const IDEMPOTENCY_KEY_PATTERN = /^[a-zA-Z0-9-]{1,64}$/;
+
+const missingCredentialsError = () =>
+  new WompiError(
+    "Payouts credentials are required for BRE-B operations: pass `payouts: { apiKey, userPrincipalId }` to the WompiClient"
+  );
+
+const authHeaders = ({ apiKey, userPrincipalId }: PayoutsCredentials): Record<string, string> => ({
+  "x-api-key": apiKey,
+  "user-principal-id": userPrincipalId,
+});
+
+/**
+ * BRE-B dispersals over the payouts API (Pagos a Terceros). Runs against
+ * `api.payouts.wompi.co` — a different host and credential pair than the
+ * payments API. Requires `payouts.apiKey` and `payouts.userPrincipalId`.
+ */
+export class Breb extends WompiRequest {
+  constructor(
+    private readonly credentials: PayoutsCredentials | undefined,
+    private readonly sandbox = false
+  ) {
+    super({ sandbox, api: "payouts" });
+  }
+
+  /**
+   * Resolve a BRE-B key and get the (masked) holder information before paying.
+   * Read-only: no transaction or fund movement happens. Show the holder data
+   * to your user for confirmation before creating the payout.
+   *
+   * @param keyValue The BRE-B key (e.g. `@JUANPEREZ`, `juan@email.com`, `3001234567`).
+   * @param keyType Optional; when sent, Wompi validates the key format against it.
+   */
+  async resolveKey(keyValue: string, keyType?: unknown): Promise<Result<BrebKeyResolution>> {
+    const { credentials } = this;
+    if (!credentials) return [missingCredentialsError(), null];
+
+    if (!keyValue) {
+      return [new WompiError("resolveKey: keyValue must be a non-empty string"), null];
+    }
+
+    let endpoint = `/breb/keys/resolve/${encodeURIComponent(keyValue)}`;
+
+    if (keyType !== undefined) {
+      const parsed = BrebKeyTypeSchema.safeParse(keyType);
+
+      if (!parsed.success) {
+        return [
+          new WompiError(`Invalid keyType: must be one of ${BrebKeyTypeSchema.options.join(", ")}`),
+          null,
+        ];
+      }
+
+      endpoint += `?keyType=${parsed.data}`;
+    }
+
+    return this.get(endpoint, KeyResolutionResponseSchema, authHeaders(credentials));
+  }
+
+  /**
+   * Create a payout batch. Each transaction pays a beneficiary either by
+   * BRE-B `key` or by traditional bank fields; both can be mixed in one batch.
+   *
+   * @param input The batch: `reference`, `accountId`, `paymentType` and `transactions`.
+   * @param idempotencyKey Unique per payment request (1-64 chars: letters,
+   *   numbers, hyphens). Reusing one within 24 hours returns a 409.
+   */
+  async createPayout(input: unknown, idempotencyKey: string): Promise<Result<CreatePayoutResult>> {
+    const { credentials } = this;
+    if (!credentials) return [missingCredentialsError(), null];
+
+    if (!IDEMPOTENCY_KEY_PATTERN.test(idempotencyKey)) {
+      return [
+        new WompiError(
+          "idempotencyKey must be 1 to 64 characters of letters, numbers, and hyphens"
+        ),
+        null,
+      ];
+    }
+
+    const parsed = CreatePayoutInputSchema.safeParse(input);
+
+    if (!parsed.success) {
+      return [
+        new WompiError(
+          `Invalid input: ${parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}`
+        ),
+        null,
+      ];
+    }
+
+    if (!this.sandbox && parsed.data.transactionStatus !== undefined) {
+      return [new WompiError("transactionStatus is available only in sandbox"), null];
+    }
+
+    return this.post("/payouts", CreatePayoutResponseSchema, parsed.data, {
+      ...authHeaders(credentials),
+      "idempotency-key": idempotencyKey,
+    });
+  }
+
+  /** Get a payout batch by ID — an alternative to waiting for `payout.updated` events. */
+  async getPayout(payoutId: string): Promise<Result<Payout>> {
+    const { credentials } = this;
+    if (!credentials) return [missingCredentialsError(), null];
+
+    return this.get(
+      `/payouts/${encodeURIComponent(payoutId)}`,
+      PayoutResponseSchema,
+      authHeaders(credentials)
+    );
+  }
+
+  /**
+   * List the individual transactions of a payout batch.
+   *
+   * Returns the provider's pagination fields and the transactions in `records`.
+   *
+   * @param options Optional `limit` and `page` (positive integers) to paginate large batches.
+   */
+  async getPayoutTransactions(
+    payoutId: string,
+    options?: { limit?: number; page?: number }
+  ): Promise<Result<PayoutTransactionPage>> {
+    const { credentials } = this;
+    if (!credentials) return [missingCredentialsError(), null];
+
+    for (const name of ["limit", "page"] as const) {
+      const value = options?.[name];
+      if (value !== undefined && (!Number.isInteger(value) || value < 1)) {
+        return [new WompiError(`${name} must be a positive integer`), null];
+      }
+    }
+
+    const params = new URLSearchParams();
+    if (options?.limit !== undefined) params.set("limit", String(options.limit));
+    if (options?.page !== undefined) params.set("page", String(options.page));
+    const query = params.toString();
+
+    return this.get(
+      `/payouts/${encodeURIComponent(payoutId)}/transactions${query ? `?${query}` : ""}`,
+      PayoutTransactionsResponseSchema,
+      authHeaders(credentials)
+    );
+  }
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -4,6 +4,7 @@ import { Tokens } from "@/client/tokens";
 import { PaymentSources } from "@/client/payment-sources";
 import { PaymentLinks } from "@/client/payment-links";
 import { PSE } from "@/client/pse";
+import { Breb } from "@/client/breb";
 import { WompiClientOptionsSchema, WompiError } from "@/schemas";
 
 export class WompiClient {
@@ -25,6 +26,9 @@ export class WompiClient {
   /** PSE operations (list financial institutions). */
   readonly pse: PSE;
 
+  /** BRE-B dispersal operations (resolve key, create payout). Requires payouts credentials. */
+  readonly breb: Breb;
+
   constructor(options: unknown) {
     const parsed = WompiClientOptionsSchema.safeParse(options);
 
@@ -34,7 +38,7 @@ export class WompiClient {
       );
     }
 
-    const { publicKey, privateKey, sandbox } = parsed.data;
+    const { publicKey, privateKey, payouts, sandbox } = parsed.data;
 
     this.merchants = new Merchants(publicKey, sandbox);
     this.transactions = new Transactions(publicKey, privateKey, sandbox);
@@ -42,5 +46,6 @@ export class WompiClient {
     this.paymentSources = new PaymentSources(privateKey, sandbox);
     this.paymentLinks = new PaymentLinks(privateKey, sandbox);
     this.pse = new PSE(publicKey, sandbox);
+    this.breb = new Breb(payouts, sandbox);
   }
 }

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -11,13 +11,24 @@ import {
 import type { Result } from "@/schemas";
 
 const BASE_URLS = {
-  production: "https://production.wompi.co/v1",
-  sandbox: "https://sandbox.wompi.co/v1",
+  payments: {
+    production: "https://production.wompi.co/v1",
+    sandbox: "https://sandbox.wompi.co/v1",
+  },
+  payouts: {
+    production: "https://api.payouts.wompi.co/v2",
+    sandbox: "https://api.sandbox.payouts.wompi.co/v2",
+  },
 } as const;
 
 export type WompiRequestConfig = {
   sandbox?: boolean;
   timeoutMs?: number;
+  /**
+   * Which Wompi API the resource talks to. Payouts (Pagos a Terceros / BRE-B)
+   * lives on a different host than the payments API. Defaults to `"payments"`.
+   */
+  api?: keyof typeof BASE_URLS;
 };
 
 export class WompiRequest {
@@ -25,7 +36,8 @@ export class WompiRequest {
   private readonly timeoutMs: number;
 
   constructor(config?: WompiRequestConfig) {
-    this.baseUrl = config?.sandbox ? BASE_URLS.sandbox : BASE_URLS.production;
+    const urls = BASE_URLS[config?.api ?? "payments"];
+    this.baseUrl = config?.sandbox ? urls.sandbox : urls.production;
     this.timeoutMs = config?.timeoutMs ?? 30_000;
   }
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -348,6 +348,223 @@ export const wompiListResponse = <T extends z.ZodType>(itemSchema: T) =>
     })
     .transform((parsed) => (parsed as { data: z.output<T>[] }).data);
 
+// ---------------------------------------------------------------------------
+// Payouts (Pagos a Terceros) · BRE-B
+//
+// These endpoints live on the payouts API (`api.payouts.wompi.co/v2`), which
+// uses camelCase field names on the wire — unlike the snake_case payments API.
+// ---------------------------------------------------------------------------
+
+export const BrebKeyTypeSchema = z.enum([
+  "ALPHANUMERIC",
+  "MAIL",
+  "PHONE",
+  "IDENTIFICATION",
+  "ESTABLISHMENT_CODE",
+]);
+
+export const PayoutPaymentTypeSchema = z.enum(["PAYROLL", "PROVIDERS", "OTHER"]);
+
+export const PayoutTransactionStatusSchema = z.enum([
+  "PENDING",
+  "PROCESSING",
+  "APPROVED",
+  "FAILED",
+  "REJECTED",
+  "CANCELLED",
+  "READY_TO_FILE",
+  "ADDED_TO_FILE",
+  "UNKNOWN",
+]);
+
+export const PayoutStatusSchema = z.enum([
+  "PENDING",
+  "PENDING_APPROVAL",
+  "NOT_APPROVED",
+  "TOTAL_PAYMENT",
+  "PARTIAL_PAYMENT",
+  "REJECTED",
+  "AFE_REJECTED",
+  "AFE_ON_HOLD",
+]);
+
+export const PayoutLegalIdTypeSchema = z.enum(["CC", "CE", "NIT", "PP", "TI", "DNI"]);
+
+export const PayoutPersonTypeSchema = z.enum(["NATURAL", "JURIDICA"]);
+
+export const PayoutAccountTypeSchema = z.enum(["AHORROS", "CORRIENTE", "DEPOSITO_ELECTRONICO"]);
+
+export const BrebFinancialEntitySchema = z
+  .object({
+    name: z.string().optional(),
+    code: z.string().optional(),
+  })
+  .loose();
+
+/**
+ * Result of resolving a BRE-B key (`GET /breb/keys/resolve/{keyValue}`).
+ * Holder data comes back partially masked by design.
+ */
+export const BrebKeyResolutionSchema = z
+  .object({
+    holderName: z.string().optional(),
+    financialEntity: BrebFinancialEntitySchema.optional(),
+    keyType: z.string().optional(),
+    keyValue: z.string().optional(),
+  })
+  .loose();
+
+export const PayoutRecurringSchema = z.object({
+  interval: z.enum(["biweek", "month"]),
+  months: z.literal([3, 6, 12], { error: "Must be 3, 6, or 12" }),
+  description: z.string().optional(),
+});
+
+/**
+ * One transaction inside a payout batch. A BRE-B transaction sends `key` in
+ * place of `bankId` + `accountType` + `accountNumber`; the beneficiary document
+ * (`legalIdType` + `legalId`) remains optional as a pair for BRE-B and is
+ * required for a bank transaction. Both kinds can be mixed in one batch, but
+ * each transaction must use exactly one destination method.
+ */
+export const PayoutTransactionInputSchema = z
+  .object({
+    amount: z.number().int().positive(),
+    name: z.string().min(1),
+    email: z.email(),
+    key: z.string().min(1).optional(),
+    bankId: z.string().min(1).optional(),
+    accountType: PayoutAccountTypeSchema.optional(),
+    accountNumber: z.string().min(1).optional(),
+    legalIdType: PayoutLegalIdTypeSchema.optional(),
+    legalId: z.string().min(1).optional(),
+    phone: z.string().optional(),
+    description: z.string().optional(),
+    personType: PayoutPersonTypeSchema.optional(),
+    reference: z
+      .string()
+      .max(40)
+      .regex(/^[a-zA-Z0-9-]+$/, "Only letters, numbers, and hyphens")
+      .optional(),
+  })
+  .refine(
+    (t) =>
+      t.key !== undefined ||
+      (t.bankId !== undefined && t.accountType !== undefined && t.accountNumber !== undefined),
+    { message: "Provide key (BRE-B) or bankId + accountType + accountNumber (bank transfer)" }
+  )
+  .refine(
+    (t) =>
+      t.key === undefined ||
+      (t.bankId === undefined && t.accountType === undefined && t.accountNumber === undefined),
+    { message: "Provide either key (BRE-B) or bank fields, not both" }
+  )
+  .refine((t) => (t.legalIdType === undefined) === (t.legalId === undefined), {
+    message: "Provide both legalIdType and legalId, or neither",
+  })
+  .refine((t) => t.key !== undefined || (t.legalIdType !== undefined && t.legalId !== undefined), {
+    message: "Bank transfers require the beneficiary document: legalIdType + legalId",
+  });
+
+export const CreatePayoutInputSchema = z
+  .object({
+    reference: z.string().min(1),
+    accountId: z.string().min(1),
+    paymentType: PayoutPaymentTypeSchema,
+    transactions: z.array(PayoutTransactionInputSchema).min(1),
+    dispersionDatetime: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/, "Must be YYYY-MM-DDTHH:mm format")
+      .optional(),
+    recurring: PayoutRecurringSchema.optional(),
+    /** Sandbox only: simulates the final status of every transaction in the batch. */
+    transactionStatus: z.enum(["APPROVED", "FAILED"]).optional(),
+  })
+  .refine((payout) => payout.recurring === undefined || payout.dispersionDatetime !== undefined, {
+    message: "dispersionDatetime is required for recurring payouts",
+    path: ["dispersionDatetime"],
+  });
+
+/**
+ * Response payload of `POST /payouts`. Lenient like every response schema:
+ * only `payoutId` — the identifier consumers persist — is required.
+ */
+export const CreatePayoutResultSchema = z
+  .object({
+    payoutId: z.string(),
+    transactions: z.number().int().optional(),
+    success: z.number().int().optional(),
+    failed: z.number().int().optional(),
+  })
+  .loose();
+
+/** Beneficiary data on a payout transaction, masked and enriched with the resolved BRE-B key. */
+export const PayoutPayeeSchema = z
+  .object({
+    bank: z.string().optional(),
+    bankCode: z.string().optional(),
+    key: z.string().optional(),
+    name: z.string().optional(),
+    email: z.string().optional(),
+    keyType: z.string().optional(),
+    legalId: z.string().optional(),
+    personType: z.string().optional(),
+    accountType: z.string().optional(),
+    legalIdType: z.string().optional(),
+    accountNumber: z.string().optional(),
+    keyResolutionId: z.string().optional(),
+    paymentMethodType: z.string().optional(),
+  })
+  .loose();
+
+export const PayoutFailureReasonSchema = z
+  .object({
+    code: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .loose();
+
+export const PayoutTransactionSchema = z
+  .object({
+    id: z.string(),
+    status: PayoutTransactionStatusSchema,
+    payoutId: z.string().optional(),
+    amountInCents: z.number().int().optional(),
+    payee: PayoutPayeeSchema.optional(),
+    payeeInfo: PayoutPayeeSchema.optional(),
+    failureReason: z.union([PayoutFailureReasonSchema, z.string()]).nullish(),
+    reference: z.string().optional(),
+    currency: z.string().optional(),
+    appliedAt: z.string().nullish(),
+    createdAt: z.string().optional(),
+  })
+  .loose();
+
+/** Paginated payload returned by `GET /payouts/{payoutId}/transactions`. */
+export const PayoutTransactionPageSchema = z
+  .object({
+    page: z.number().int().positive().optional(),
+    limit: z.number().int().positive().optional(),
+    total: z.number().int().nonnegative().optional(),
+    pages: z.number().int().nonnegative().optional(),
+    records: z.array(PayoutTransactionSchema),
+  })
+  .loose();
+
+export const PayoutSchema = z
+  .object({
+    id: z.string(),
+    status: PayoutStatusSchema,
+    reference: z.string().optional(),
+    amountInCents: z.number().int().optional(),
+    paymentType: z.string().optional(),
+    totalTransactions: z.number().int().optional(),
+    currency: z.string().optional(),
+    approvedAt: z.string().nullish(),
+    createdAt: z.string().optional(),
+  })
+  .loose();
+
 export const WebhookSignatureSchema = z.object({
   properties: z.array(z.string()),
   checksum: z.string(),
@@ -368,6 +585,17 @@ export const WebhookEventSchema = z
     signature: WebhookSignatureSchema,
     timestamp: z.number(),
     sent_at: z.string().optional(),
+  })
+  .loose();
+
+/** Generic envelope for payouts events, which use `sentAt` and omit `environment`. */
+export const PayoutWebhookEventSchema = z
+  .object({
+    event: z.string(),
+    data: z.record(z.string(), z.unknown()),
+    signature: WebhookSignatureSchema,
+    timestamp: z.number(),
+    sentAt: z.string().optional(),
   })
   .loose();
 
@@ -393,6 +621,33 @@ export const NequiTokenUpdatedEventSchema = z
   })
   .loose();
 
+/**
+ * `transaction.updated` fired by the payouts API for a BRE-B/bank dispersal.
+ * It shares its name with the payments-API event; `transaction.payoutId` —
+ * required here — is what tells them apart. Uses camelCase `sentAt` and omits
+ * `environment`, unlike payments-API events.
+ */
+export const PayoutTransactionUpdatedEventSchema = z
+  .object({
+    event: z.literal("transaction.updated"),
+    data: z.object({ transaction: PayoutTransactionSchema.extend({ payoutId: z.string() }) }),
+    signature: WebhookSignatureSchema,
+    timestamp: z.number(),
+    sentAt: z.string().optional(),
+  })
+  .loose();
+
+/** `payout.updated` fired by the payouts API when a whole batch changes status. */
+export const PayoutUpdatedEventSchema = z
+  .object({
+    event: z.literal("payout.updated"),
+    data: z.object({ payout: PayoutSchema }),
+    signature: WebhookSignatureSchema,
+    timestamp: z.number(),
+    sentAt: z.string().optional(),
+  })
+  .loose();
+
 export const NotFoundErrorResponseSchema = z.object({
   error: z.object({
     type: z.literal("NOT_FOUND_ERROR"),
@@ -407,9 +662,20 @@ export const InputValidationErrorResponseSchema = z.object({
   }),
 });
 
+/**
+ * Credentials for the payouts API (Pagos a Terceros / BRE-B). These are
+ * separate from the payments keys and come from the "Pagos a Terceros"
+ * section of the Wompi dashboard.
+ */
+export const PayoutsCredentialsSchema = z.object({
+  apiKey: z.string().min(1, "A payouts API key is required"),
+  userPrincipalId: z.string().min(1, "A payouts user principal id is required"),
+});
+
 export const WompiClientOptionsSchema = z.object({
   publicKey: z.string().min(1, "A public key is required"),
   privateKey: z.string().optional(),
+  payouts: PayoutsCredentialsSchema.optional(),
   sandbox: z.boolean().default(false),
 });
 
@@ -462,10 +728,33 @@ export type Merchant = z.output<typeof MerchantSchema>;
 
 export type FinancialInstitution = z.output<typeof FinancialInstitutionSchema>;
 
+export type BrebKeyType = z.output<typeof BrebKeyTypeSchema>;
+export type PayoutPaymentType = z.output<typeof PayoutPaymentTypeSchema>;
+export type PayoutTransactionStatus = z.output<typeof PayoutTransactionStatusSchema>;
+export type PayoutStatus = z.output<typeof PayoutStatusSchema>;
+export type PayoutLegalIdType = z.output<typeof PayoutLegalIdTypeSchema>;
+export type PayoutPersonType = z.output<typeof PayoutPersonTypeSchema>;
+export type PayoutAccountType = z.output<typeof PayoutAccountTypeSchema>;
+export type BrebFinancialEntity = z.output<typeof BrebFinancialEntitySchema>;
+export type BrebKeyResolution = z.output<typeof BrebKeyResolutionSchema>;
+export type PayoutRecurring = z.output<typeof PayoutRecurringSchema>;
+export type PayoutTransactionInput = z.output<typeof PayoutTransactionInputSchema>;
+export type CreatePayoutInput = z.output<typeof CreatePayoutInputSchema>;
+export type CreatePayoutResult = z.output<typeof CreatePayoutResultSchema>;
+export type PayoutPayee = z.output<typeof PayoutPayeeSchema>;
+export type PayoutFailureReason = z.output<typeof PayoutFailureReasonSchema>;
+export type PayoutTransaction = z.output<typeof PayoutTransactionSchema>;
+export type PayoutTransactionPage = z.output<typeof PayoutTransactionPageSchema>;
+export type Payout = z.output<typeof PayoutSchema>;
+export type PayoutsCredentials = z.output<typeof PayoutsCredentialsSchema>;
+
 export type WebhookSignature = z.output<typeof WebhookSignatureSchema>;
 export type WebhookEvent = z.output<typeof WebhookEventSchema>;
+export type PayoutWebhookEvent = z.output<typeof PayoutWebhookEventSchema>;
 export type TransactionUpdatedEvent = z.output<typeof TransactionUpdatedEventSchema>;
 export type NequiTokenUpdatedEvent = z.output<typeof NequiTokenUpdatedEventSchema>;
+export type PayoutTransactionUpdatedEvent = z.output<typeof PayoutTransactionUpdatedEventSchema>;
+export type PayoutUpdatedEvent = z.output<typeof PayoutUpdatedEventSchema>;
 
 export type NotFoundErrorResponse = z.output<typeof NotFoundErrorResponseSchema>;
 export type InputValidationErrorResponse = z.output<typeof InputValidationErrorResponseSchema>;

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,10 +1,20 @@
 import {
+  PayoutTransactionUpdatedEventSchema,
+  PayoutWebhookEventSchema,
+  PayoutUpdatedEventSchema,
   TransactionUpdatedEventSchema,
   WebhookEventSchema,
   WompiError,
   WompiWebhookVerificationError,
 } from "@/schemas";
-import type { Result, TransactionUpdatedEvent, WebhookEvent } from "@/schemas";
+import type {
+  PayoutTransactionUpdatedEvent,
+  PayoutUpdatedEvent,
+  PayoutWebhookEvent,
+  Result,
+  TransactionUpdatedEvent,
+  WebhookEvent,
+} from "@/schemas";
 
 /** SHA-256 hex digest (lowercase) of a UTF-8 string, via Web Crypto. */
 const sha256Hex = async (input: string): Promise<string> => {
@@ -123,6 +133,8 @@ export const computeEventChecksum = async (
 export type VerifyWebhookEventOptions = {
   /** The merchant events secret, available in the Wompi dashboard. */
   eventsKey: string;
+  /** Select the payouts envelope, which omits `environment` and uses `sentAt`. */
+  api?: "payments" | "payouts";
 };
 
 /**
@@ -132,7 +144,8 @@ export type VerifyWebhookEventOptions = {
  * validates the envelope shape, recomputes the checksum with the events secret
  * and compares it in constant time against `signature.checksum`. Events whose
  * checksum does not match must be discarded — anyone can POST to a public
- * webhook endpoint.
+ * webhook endpoint. Pass `api: "payouts"` with the payouts events secret for
+ * BRE-B and bank-dispersal events, whose envelope omits `environment`.
  *
  * @example
  * ```ts
@@ -145,10 +158,22 @@ export type VerifyWebhookEventOptions = {
  * }
  * ```
  */
-export const verifyWebhookEvent = async (
+export function verifyWebhookEvent(
+  payload: unknown,
+  options: VerifyWebhookEventOptions & { api: "payouts" }
+): Promise<Result<PayoutWebhookEvent>>;
+export function verifyWebhookEvent(
+  payload: unknown,
+  options: VerifyWebhookEventOptions & { api?: "payments" }
+): Promise<Result<WebhookEvent>>;
+export function verifyWebhookEvent(
   payload: unknown,
   options: VerifyWebhookEventOptions
-): Promise<Result<WebhookEvent>> => {
+): Promise<Result<WebhookEvent | PayoutWebhookEvent>>;
+export async function verifyWebhookEvent(
+  payload: unknown,
+  options: VerifyWebhookEventOptions
+): Promise<Result<WebhookEvent | PayoutWebhookEvent>> {
   let raw: unknown = payload;
 
   if (typeof payload === "string") {
@@ -159,7 +184,8 @@ export const verifyWebhookEvent = async (
     }
   }
 
-  const parsed = WebhookEventSchema.safeParse(raw);
+  const schema = options.api === "payouts" ? PayoutWebhookEventSchema : WebhookEventSchema;
+  const parsed = schema.safeParse(raw);
 
   if (!parsed.success) {
     return [
@@ -178,11 +204,30 @@ export const verifyWebhookEvent = async (
   }
 
   return [null, event];
-};
+}
 
-/** Narrow a verified {@link WebhookEvent} to a typed `transaction.updated` event. */
-export const isTransactionUpdatedEvent = (event: WebhookEvent): event is TransactionUpdatedEvent =>
+/** Narrow a verified payments or payouts event to a payment `transaction.updated` event. */
+export const isTransactionUpdatedEvent = (
+  event: WebhookEvent | PayoutWebhookEvent
+): event is TransactionUpdatedEvent =>
   event.event === "transaction.updated" && TransactionUpdatedEventSchema.safeParse(event).success;
+
+/**
+ * Narrow a verified {@link WebhookEvent} to a payouts-API (BRE-B/bank dispersal)
+ * `transaction.updated` event. The event name is shared with the payments API;
+ * the payload's `transaction.payoutId` is what tells them apart.
+ */
+export const isPayoutTransactionUpdatedEvent = (
+  event: WebhookEvent | PayoutWebhookEvent
+): event is PayoutTransactionUpdatedEvent =>
+  event.event === "transaction.updated" &&
+  PayoutTransactionUpdatedEventSchema.safeParse(event).success;
+
+/** Narrow a verified payments or payouts event to a typed `payout.updated` event. */
+export const isPayoutUpdatedEvent = (
+  event: WebhookEvent | PayoutWebhookEvent
+): event is PayoutUpdatedEvent =>
+  event.event === "payout.updated" && PayoutUpdatedEventSchema.safeParse(event).success;
 
 // ---------------------------------------------------------------------------
 // Web Checkout

--- a/packages/core/test/breb.test.ts
+++ b/packages/core/test/breb.test.ts
@@ -1,0 +1,742 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { WompiClient } from "../src";
+import { WompiError, WompiRequestError } from "../src/schemas";
+import { okJson, errorJson } from "./helpers";
+
+describe("Breb", () => {
+  const mockFetch = vi.fn();
+  const API_KEY = "payouts_api_key_123";
+  const USER_PRINCIPAL_ID = "63416484-e3e2-48ff-8f0d-20877cd0d161";
+
+  const makeClient = (sandbox = true) =>
+    new WompiClient({
+      publicKey: "pub_test_123",
+      payouts: { apiKey: API_KEY, userPrincipalId: USER_PRINCIPAL_ID },
+      sandbox,
+    }).breb;
+
+  const withoutCredentials = () => new WompiClient({ publicKey: "pub_test_123" }).breb;
+
+  const payoutInput = () => ({
+    reference: "payout-breb-001",
+    accountId: "84a339e8-c277-45bd-b652-50f0b689edf7",
+    paymentType: "PROVIDERS",
+    transactions: [
+      {
+        amount: 150_000,
+        name: "Juan Perez",
+        email: "juan@example.com",
+        key: "@juanperez",
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("resolveKey", () => {
+    it("resolves a key against the payouts sandbox host with auth headers", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          status: 200,
+          code: "OK",
+          message: "Solicitud ejecutada correctamente.",
+          meta: { trace_id: "6fbfdee0-1ed8-11f0-acf5-eb60899d3e82" },
+          data: {
+            holderName: "JUA*** PER*** GAR***",
+            financialEntity: { name: "BANCOLOMBIA", code: "001" },
+            keyType: "ALPHANUMERIC",
+            keyValue: "@JUA***",
+          },
+        })
+      );
+
+      const [error, data] = await breb.resolveKey("@JUANPEREZ", "ALPHANUMERIC");
+
+      expect(error).toBeNull();
+      expect(data?.holderName).toBe("JUA*** PER*** GAR***");
+      expect(data?.financialEntity?.name).toBe("BANCOLOMBIA");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        "https://api.sandbox.payouts.wompi.co/v2/breb/keys/resolve/%40JUANPEREZ?keyType=ALPHANUMERIC"
+      );
+      expect(options.method).toBe("GET");
+      expect(options.headers["x-api-key"]).toBe(API_KEY);
+      expect(options.headers["user-principal-id"]).toBe(USER_PRINCIPAL_ID);
+    });
+
+    it("uses the payouts production host when sandbox is false", async () => {
+      const breb = makeClient(false);
+
+      mockFetch.mockResolvedValueOnce(okJson({ data: {} }));
+
+      await breb.resolveKey("3001234567");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.payouts.wompi.co/v2/breb/keys/resolve/3001234567");
+    });
+
+    it("omits the keyType query when not provided", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(okJson({ data: {} }));
+
+      await breb.resolveKey("juan@email.com");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).not.toContain("keyType");
+      expect(url).toContain("/breb/keys/resolve/juan%40email.com");
+    });
+
+    it("rejects an invalid keyType without calling the API", async () => {
+      const [error, data] = await makeClient().resolveKey("@JUANPEREZ", "PASSPORT");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("Invalid keyType");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty keyValue without calling the API", async () => {
+      const [error, data] = await makeClient().resolveKey("");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns [WompiError, null] when payouts credentials are missing", async () => {
+      const [error, data] = await withoutCredentials().resolveKey("@JUANPEREZ");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("Payouts credentials are required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("surfaces an unknown-key 404 as a WompiRequestError with the payouts body", async () => {
+      const body = {
+        status: 404,
+        meta: { trace_id: "6fbfdee0-1ed8-11f0-acf5-eb60899d3e82" },
+        code: "EXC_034",
+        message: "La llave BRE-B no se encuentra activa o no está registrada.",
+        type: "Business",
+      };
+
+      mockFetch.mockResolvedValueOnce(errorJson(404, body));
+
+      const [error, data] = await makeClient().resolveKey("noexiste@test.com");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiRequestError);
+      expect((error as WompiRequestError).statusCode).toBe(404);
+      expect((error as WompiRequestError).body).toEqual(body);
+    });
+  });
+
+  describe("createPayout", () => {
+    it("creates a payout with auth and idempotency headers", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson(
+          {
+            status: 201,
+            code: "OK",
+            message: "Solicitud ejecutada correctamente.",
+            data: {
+              payoutId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+              transactions: 1,
+              success: 1,
+              failed: 0,
+            },
+          },
+          201
+        )
+      );
+
+      const [error, data] = await breb.createPayout(payoutInput(), "payout-unique-key-001");
+
+      expect(error).toBeNull();
+      expect(data?.payoutId).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+      expect(data?.success).toBe(1);
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("https://api.sandbox.payouts.wompi.co/v2/payouts");
+      expect(options.method).toBe("POST");
+      expect(options.headers["x-api-key"]).toBe(API_KEY);
+      expect(options.headers["user-principal-id"]).toBe(USER_PRINCIPAL_ID);
+      expect(options.headers["idempotency-key"]).toBe("payout-unique-key-001");
+      expect(JSON.parse(options.body)).toEqual(payoutInput());
+    });
+
+    it("accepts a mixed batch of BRE-B and bank transactions", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-1" } }, 201));
+
+      const [error] = await breb.createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            { amount: 150_000, name: "Juan Perez", email: "juan@example.com", key: "@juanperez" },
+            {
+              amount: 250_000,
+              name: "Carlos Gomez",
+              email: "carlos@example.com",
+              legalIdType: "CC",
+              legalId: "1234567890",
+              bankId: "9183a03b-cd82-451a-a6c7-6a9ab406a477",
+              accountType: "AHORROS",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-mixed-key-001"
+      );
+
+      expect(error).toBeNull();
+    });
+
+    it("accepts optional beneficiary document fields with a BRE-B key", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-breb-document" } }, 201));
+
+      const input = {
+        ...payoutInput(),
+        transactions: [
+          {
+            amount: 150_000,
+            name: "Juan Perez",
+            email: "juan@example.com",
+            key: "@juanperez",
+            legalIdType: "CC",
+            legalId: "1234567890",
+          },
+        ],
+      };
+      const [error] = await makeClient().createPayout(input, "payout-breb-document-001");
+
+      expect(error).toBeNull();
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body)).toEqual(input);
+    });
+
+    it.each([
+      ["legalIdType only", { legalIdType: "CC" }],
+      ["legalId only", { legalId: "1234567890" }],
+    ])("rejects partial beneficiary document fields with a BRE-B key: %s", async (_, document) => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-partial-document" } }, 201));
+
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Juan Perez",
+              email: "juan@example.com",
+              key: "@juanperez",
+              ...document,
+            },
+          ],
+        },
+        "payout-breb-partial-document-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("both legalIdType and legalId");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects recurring payouts without a dispersion date", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-recurring" } }, 201));
+
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          recurring: { interval: "month", months: 6 },
+        },
+        "payout-recurring-key-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("dispersionDatetime");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects recurring month counts outside 3, 6, or 12", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-recurring" } }, 201));
+
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          dispersionDatetime: "2026-08-15T10:00",
+          recurring: { interval: "month", months: 4 },
+        },
+        "payout-recurring-months-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("3, 6, or 12");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("passes the sandbox-only transactionStatus simulation field through", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-2" } }, 201));
+
+      await breb.createPayout(
+        { ...payoutInput(), transactionStatus: "FAILED" },
+        "payout-failed-key-001"
+      );
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body).transactionStatus).toBe("FAILED");
+    });
+
+    it("rejects the sandbox-only transactionStatus field in production", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-production" } }, 201));
+
+      const [error, data] = await makeClient(false).createPayout(
+        { ...payoutInput(), transactionStatus: "FAILED" },
+        "payout-production-status-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("sandbox");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a transaction with neither a key nor bank details", async () => {
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [{ amount: 150_000, name: "Juan Perez", email: "juan@example.com" }],
+        },
+        "payout-invalid-key-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("Provide key (BRE-B) or bankId");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bank transaction missing accountType", async () => {
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Carlos Gomez",
+              email: "carlos@example.com",
+              bankId: "9183a03b-cd82-451a-a6c7-6a9ab406a477",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-no-account-type-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("Provide key (BRE-B) or bankId");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects blank required bank destination fields", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-bank" } }, 201));
+
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Carlos Gomez",
+              email: "carlos@example.com",
+              legalIdType: "CC",
+              legalId: "1234567890",
+              bankId: "",
+              accountType: "AHORROS",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-blank-bank-id-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects unsupported bank account types", async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ data: { payoutId: "p-bank" } }, 201));
+
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Carlos Gomez",
+              email: "carlos@example.com",
+              legalIdType: "CC",
+              legalId: "1234567890",
+              bankId: "9183a03b-cd82-451a-a6c7-6a9ab406a477",
+              accountType: "SAVINGS",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-invalid-account-type-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a bank transaction missing the beneficiary document", async () => {
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Carlos Gomez",
+              email: "carlos@example.com",
+              bankId: "9183a03b-cd82-451a-a6c7-6a9ab406a477",
+              accountType: "AHORROS",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-no-legal-id-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("legalIdType + legalId");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a transaction with both a key and bank details", async () => {
+      const [error, data] = await makeClient().createPayout(
+        {
+          ...payoutInput(),
+          transactions: [
+            {
+              amount: 150_000,
+              name: "Juan Perez",
+              email: "juan@example.com",
+              key: "@juanperez",
+              bankId: "9183a03b-cd82-451a-a6c7-6a9ab406a477",
+              accountType: "AHORROS",
+              accountNumber: "9876543210",
+            },
+          ],
+        },
+        "payout-both-methods-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("not both");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects an idempotency key with characters other than letters, numbers, and hyphens", async () => {
+      const [error, data] = await makeClient().createPayout(payoutInput(), "payout_key!");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("idempotencyKey");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects an idempotency key longer than 64 characters", async () => {
+      const [error] = await makeClient().createPayout(payoutInput(), "a".repeat(65));
+
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid input without calling the API", async () => {
+      const [error, data] = await makeClient().createPayout(
+        { reference: "", transactions: [] },
+        "payout-empty-key-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(error?.message).toContain("Invalid input");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns [WompiError, null] when payouts credentials are missing", async () => {
+      const [error, data] = await withoutCredentials().createPayout(
+        payoutInput(),
+        "payout-no-creds-001"
+      );
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a duplicated idempotency key 409 as a WompiRequestError", async () => {
+      const body = {
+        status: 409,
+        code: "EXC_032",
+        message: "La llave de idempotencia ya fue procesada.",
+        type: "Business",
+      };
+
+      mockFetch.mockResolvedValueOnce(errorJson(409, body));
+
+      const [error, data] = await makeClient().createPayout(payoutInput(), "payout-dup-key-001");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiRequestError);
+      expect((error as WompiRequestError).statusCode).toBe(409);
+      expect((error as WompiRequestError).body).toEqual(body);
+    });
+  });
+
+  describe("getPayout", () => {
+    it("fetches a payout batch by id", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          data: {
+            id: "c57a05b0-646c-11f1-8436-6ca5ce550b83",
+            reference: "payout-breb-001",
+            amountInCents: 150_000,
+            paymentType: "PROVIDERS",
+            status: "TOTAL_PAYMENT",
+            totalTransactions: 1,
+            currency: "COP",
+          },
+        })
+      );
+
+      const [error, data] = await breb.getPayout("c57a05b0-646c-11f1-8436-6ca5ce550b83");
+
+      expect(error).toBeNull();
+      expect(data?.status).toBe("TOTAL_PAYMENT");
+
+      const [url, options] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        "https://api.sandbox.payouts.wompi.co/v2/payouts/c57a05b0-646c-11f1-8436-6ca5ce550b83"
+      );
+      expect(options.headers["x-api-key"]).toBe(API_KEY);
+    });
+
+    it("parses the approval-flow statuses PENDING_APPROVAL and NOT_APPROVED", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({ data: { id: "p-approval", status: "PENDING_APPROVAL" } })
+      );
+      mockFetch.mockResolvedValueOnce(
+        okJson({ data: { id: "p-approval", status: "NOT_APPROVED" } })
+      );
+
+      const [pendingError, pending] = await breb.getPayout("p-approval");
+      const [notApprovedError, notApproved] = await breb.getPayout("p-approval");
+
+      expect(pendingError).toBeNull();
+      expect(pending?.status).toBe("PENDING_APPROVAL");
+      expect(notApprovedError).toBeNull();
+      expect(notApproved?.status).toBe("NOT_APPROVED");
+    });
+
+    it("parses the AFE review statuses AFE_ON_HOLD and AFE_REJECTED", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(okJson({ data: { id: "p-afe", status: "AFE_ON_HOLD" } }));
+      mockFetch.mockResolvedValueOnce(okJson({ data: { id: "p-afe", status: "AFE_REJECTED" } }));
+
+      const [onHoldError, onHold] = await breb.getPayout("p-afe");
+      const [rejectedError, rejected] = await breb.getPayout("p-afe");
+
+      expect(onHoldError).toBeNull();
+      expect(onHold?.status).toBe("AFE_ON_HOLD");
+      expect(rejectedError).toBeNull();
+      expect(rejected?.status).toBe("AFE_REJECTED");
+    });
+
+    it("returns [WompiError, null] when payouts credentials are missing", async () => {
+      const [error, data] = await withoutCredentials().getPayout("p-1");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getPayoutTransactions", () => {
+    it("parses Wompi's documented paginated records envelope", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          status: 200,
+          code: "OK",
+          message: "Solicitud ejecutada correctamente.",
+          meta: { trace_id: "2796d870-21e5-11f0-805b-4b055319fe18" },
+          data: {
+            page: 2,
+            limit: 10,
+            total: 21,
+            pages: 3,
+            records: [
+              {
+                id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                amountInCents: 150_000,
+                status: "FAILED",
+                payeeInfo: { name: "Carlos Gomez", accountNumber: "**3210" },
+                failureReason: "Cuenta cerrada",
+                reference: "order-42",
+                appliedAt: "2026-07-21T10:00:00.000Z",
+                createdAt: "2026-07-21T09:59:00.000Z",
+              },
+            ],
+          },
+        })
+      );
+
+      const [error, data] = await breb.getPayoutTransactions("payout-1", {
+        limit: 10,
+        page: 2,
+      });
+
+      expect(error).toBeNull();
+      expect(data?.page).toBe(2);
+      expect(data?.pages).toBe(3);
+      expect(data?.records).toHaveLength(1);
+      expect(data?.records[0]?.failureReason).toBe("Cuenta cerrada");
+      expect(data?.records[0]?.payeeInfo?.accountNumber).toBe("**3210");
+    });
+
+    it("lists the transactions of a payout batch", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          data: {
+            page: 1,
+            limit: 10,
+            total: 1,
+            pages: 1,
+            records: [
+              {
+                id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                payoutId: "c57a05b0-646c-11f1-8436-6ca5ce550b83",
+                amountInCents: 150_000,
+                status: "APPROVED",
+                payee: { key: "@juanperez", keyType: "ALPHANUMERIC" },
+                currency: "COP",
+              },
+            ],
+          },
+        })
+      );
+
+      const [error, data] = await breb.getPayoutTransactions(
+        "c57a05b0-646c-11f1-8436-6ca5ce550b83"
+      );
+
+      expect(error).toBeNull();
+      expect(data?.records).toHaveLength(1);
+      expect(data?.records[0]!.status).toBe("APPROVED");
+      expect(data?.records[0]!.payee?.key).toBe("@juanperez");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        "https://api.sandbox.payouts.wompi.co/v2/payouts/c57a05b0-646c-11f1-8436-6ca5ce550b83/transactions"
+      );
+    });
+
+    it("passes limit and page as query params", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({ data: { page: 2, limit: 50, total: 0, pages: 0, records: [] } })
+      );
+
+      const [error] = await breb.getPayoutTransactions("c57a05b0-646c-11f1-8436-6ca5ce550b83", {
+        limit: 50,
+        page: 2,
+      });
+
+      expect(error).toBeNull();
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        "https://api.sandbox.payouts.wompi.co/v2/payouts/c57a05b0-646c-11f1-8436-6ca5ce550b83/transactions?limit=50&page=2"
+      );
+    });
+
+    it("parses a CANCELLED transaction status", async () => {
+      const breb = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          data: {
+            page: 1,
+            limit: 10,
+            total: 1,
+            pages: 1,
+            records: [{ id: "t-cancelled", status: "CANCELLED" }],
+          },
+        })
+      );
+
+      const [error, data] = await breb.getPayoutTransactions("p-1");
+
+      expect(error).toBeNull();
+      expect(data?.records[0]!.status).toBe("CANCELLED");
+    });
+
+    it("rejects a non-positive or non-integer limit or page without calling the API", async () => {
+      const breb = makeClient();
+
+      for (const options of [{ limit: 0 }, { limit: 2.5 }, { page: -1 }, { page: 1.5 }]) {
+        const [error, data] = await breb.getPayoutTransactions("p-1", options);
+
+        expect(data).toBeNull();
+        expect(error).toBeInstanceOf(WompiError);
+        expect(error?.message).toContain("positive integer");
+      }
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns [WompiError, null] when payouts credentials are missing", async () => {
+      const [error, data] = await withoutCredentials().getPayoutTransactions("p-1");
+
+      expect(data).toBeNull();
+      expect(error).toBeInstanceOf(WompiError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -13,6 +13,22 @@ describe("WompiClient", () => {
     expect(client.paymentSources).toBeDefined();
     expect(client.paymentLinks).toBeDefined();
     expect(client.pse).toBeDefined();
+    expect(client.breb).toBeDefined();
+  });
+
+  it("should accept payouts credentials", () => {
+    const client = new WompiClient({
+      publicKey: "pub_test_123",
+      payouts: { apiKey: "payouts_key", userPrincipalId: "principal-id" },
+    });
+
+    expect(client.breb).toBeDefined();
+  });
+
+  it("should throw WompiError on incomplete payouts credentials", () => {
+    expect(
+      () => new WompiClient({ publicKey: "pub_test_123", payouts: { apiKey: "payouts_key" } })
+    ).toThrow(WompiError);
   });
 
   it("should create a client with both public and private keys", () => {

--- a/packages/core/test/integration/breb.test.ts
+++ b/packages/core/test/integration/breb.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { WompiClient } from "../../src";
+import { WompiRequestError } from "../../src/schemas";
+
+/**
+ * BRE-B dispersal lifecycle against the real payouts sandbox: resolve a test
+ * key, create a payout with it, then poll the batch until it settles.
+ *
+ * Gated on the payouts credentials, which are separate from the payments keys
+ * (Wompi dashboard > Desarrollo > Programadores > Pagos a Terceros > Sandbox).
+ * Put them in the repo-root `.env.local` (loaded by `test/setup.ts`):
+ *
+ *   WOMPI_PAYOUTS_API_KEY=...
+ *   WOMPI_PAYOUTS_USER_PRINCIPAL_ID=...
+ *   WOMPI_PAYOUTS_ACCOUNT_ID=...   # source account, needs sandbox balance
+ *
+ * The default `pnpm test` / CI run skips this suite. The client is built
+ * lazily because `describe.skipIf` still runs the describe body.
+ */
+const apiKey = process.env.WOMPI_PAYOUTS_API_KEY;
+const userPrincipalId = process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID;
+const accountId = process.env.WOMPI_PAYOUTS_ACCOUNT_ID;
+const canRun = Boolean(apiKey && userPrincipalId && accountId);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const sandboxClient = () =>
+  new WompiClient({
+    publicKey: process.env.WOMPI_PUBLIC_KEY ?? "pub_test_placeholder",
+    payouts: {
+      apiKey: apiKey ?? "",
+      userPrincipalId: userPrincipalId ?? "",
+    },
+    sandbox: true,
+  });
+
+describe.skipIf(!canRun)("sandbox · BRE-B dispersal lifecycle", () => {
+  it("resolves the @elias123 test key", async () => {
+    const [error, resolution] = await sandboxClient().breb.resolveKey("@elias123", "ALPHANUMERIC");
+
+    expect(error).toBeNull();
+    expect(resolution?.holderName).toBeTruthy();
+    expect(resolution?.financialEntity?.name).toBeTruthy();
+  });
+
+  it("resolves an unknown key to a 404 with code EXC_034", async () => {
+    const [error, data] = await sandboxClient().breb.resolveKey("noexiste@test.com", "MAIL");
+
+    expect(data).toBeNull();
+    expect(error).toBeInstanceOf(WompiRequestError);
+    expect((error as WompiRequestError).statusCode).toBe(404);
+  });
+
+  it("creates a BRE-B payout, then reads the batch and its transactions", async () => {
+    const wompi = sandboxClient();
+    const reference = `sdk-it-breb-${Date.now()}`;
+
+    // 1. Resolve the key so the flow mirrors the recommended integration.
+    const [resolveError] = await wompi.breb.resolveKey("@elias123", "ALPHANUMERIC");
+    expect(resolveError).toBeNull();
+
+    // 2. Create the dispersal; sandbox approves it by default.
+    const [createError, created] = await wompi.breb.createPayout(
+      {
+        reference,
+        accountId: accountId ?? "",
+        paymentType: "PROVIDERS",
+        transactions: [
+          {
+            amount: 150_000,
+            name: "Elias Cantor",
+            email: "elias@example.com",
+            key: "@elias123",
+          },
+        ],
+      },
+      reference
+    );
+    expect(createError).toBeNull();
+    const payoutId = created?.payoutId;
+    expect(payoutId).toBeTruthy();
+
+    // 3. Poll the batch until the sandbox settles it.
+    let status: string | undefined;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const [getError, payout] = await wompi.breb.getPayout(payoutId ?? "");
+      expect(getError).toBeNull();
+      status = payout?.status;
+      if (status && status !== "PENDING") break;
+      await sleep(2_000);
+    }
+    expect(status).toBe("TOTAL_PAYMENT");
+
+    // 4. The batch's transactions carry the resolved BRE-B payee.
+    const [txError, transactionPage] = await wompi.breb.getPayoutTransactions(payoutId ?? "");
+    expect(txError).toBeNull();
+    expect(transactionPage?.records.length).toBeGreaterThan(0);
+    expect(transactionPage?.records[0]!.status).toBe("APPROVED");
+  }, 60_000);
+});

--- a/packages/core/test/webhooks.test-d.ts
+++ b/packages/core/test/webhooks.test-d.ts
@@ -1,0 +1,25 @@
+import { expectTypeOf, test } from "vitest";
+import {
+  isPayoutTransactionUpdatedEvent,
+  isPayoutUpdatedEvent,
+  isTransactionUpdatedEvent,
+  verifyWebhookEvent,
+} from "../src/server";
+import type { VerifyWebhookEventOptions } from "../src/server";
+import type { PayoutWebhookEvent, Result, WebhookEvent } from "../src/schemas";
+
+test("supports runtime-selected webhook APIs and guard composition", async () => {
+  const payload: unknown = {};
+  const options = {} as VerifyWebhookEventOptions;
+
+  const result = verifyWebhookEvent(payload, options);
+
+  expectTypeOf(result).toEqualTypeOf<Promise<Result<WebhookEvent | PayoutWebhookEvent>>>();
+
+  const [, event] = await result;
+  if (!event) return;
+
+  isTransactionUpdatedEvent(event);
+  isPayoutTransactionUpdatedEvent(event);
+  isPayoutUpdatedEvent(event);
+});

--- a/packages/core/test/webhooks.test.ts
+++ b/packages/core/test/webhooks.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { computeEventChecksum, isTransactionUpdatedEvent, verifyWebhookEvent } from "../src/server";
+import {
+  computeEventChecksum,
+  isPayoutTransactionUpdatedEvent,
+  isPayoutUpdatedEvent,
+  isTransactionUpdatedEvent,
+  verifyWebhookEvent,
+} from "../src/server";
+import type { VerifyWebhookEventOptions } from "../src/server";
 import { WompiWebhookVerificationError } from "../src/schemas";
-import type { WebhookEvent } from "../src/schemas";
+import type { PayoutWebhookEvent, WebhookEvent } from "../src/schemas";
 
 const EVENTS_KEY = "test_events_EqCPDEn5x4lRatGPxLhyZd6YTgd6QSrr";
 
@@ -116,6 +123,166 @@ describe("verifyWebhookEvent", () => {
 
     expect(error).toBeInstanceOf(WompiWebhookVerificationError);
     expect(error?.message).toMatch(/Invalid webhook payload/);
+  });
+
+  it("rejects a payments event that omits environment", async () => {
+    const event = transactionEvent();
+    delete (event as Partial<WebhookEvent>).environment;
+
+    const [error, verified] = await verifyWebhookEvent(event, { eventsKey: EVENTS_KEY });
+
+    expect(error).toBeInstanceOf(WompiWebhookVerificationError);
+    expect(verified).toBeNull();
+  });
+});
+
+/**
+ * Payouts (BRE-B) events differ from payments-API events: no `environment`
+ * field and camelCase `sentAt`. Checksum vectors computed the same way as
+ * above, over <property values><timestamp><eventsKey>.
+ */
+const PAYOUT_TX_CHECKSUM = "ade7ad572b2328d6492c29e1ccbc9d69f4b1ef5481620b05c294d56fb2222aaf";
+const PAYOUT_CHECKSUM = "770db8e0cd4c6d3fe398dcc732bdfdcb058986e0b511c18c41debc193d8a953c";
+
+const payoutTransactionEvent = (): PayoutWebhookEvent => ({
+  event: "transaction.updated",
+  data: {
+    transaction: {
+      id: "7ee824ed-6450-49d8-8b4c-cca181414f5f",
+      payoutId: "c57a05b0-646c-11f1-8436-6ca5ce550b83",
+      amountInCents: 150_000,
+      status: "APPROVED",
+      payee: {
+        key: "@juanperez",
+        name: "Juan Perez",
+        email: "juan@example.com",
+        keyType: "ALPHANUMERIC",
+        keyResolutionId: "d7ed17c1-757d-22f2-93c2-2cc1f5c52b2a",
+        paymentMethodType: "SAVING_ACCOUNT",
+      },
+      currency: "COP",
+    },
+  },
+  signature: {
+    properties: ["transaction.id", "transaction.status", "transaction.amountInCents"],
+    checksum: PAYOUT_TX_CHECKSUM,
+  },
+  timestamp: 1781055930000,
+  sentAt: "2026-06-10T02:15:30.500Z",
+});
+
+const payoutUpdatedEvent = (): PayoutWebhookEvent => ({
+  event: "payout.updated",
+  data: {
+    payout: {
+      id: "c57a05b0-646c-11f1-8436-6ca5ce550b83",
+      reference: "payout-breb-001",
+      amountInCents: 150_000,
+      paymentType: "PROVIDERS",
+      status: "TOTAL_PAYMENT",
+      totalTransactions: 1,
+      currency: "COP",
+    },
+  },
+  signature: {
+    properties: ["payout.id", "payout.status", "payout.amountInCents"],
+    checksum: PAYOUT_CHECKSUM,
+  },
+  timestamp: 1781056530000,
+  sentAt: "2026-06-15T10:05:30.500Z",
+});
+
+describe("verifyWebhookEvent · payouts (BRE-B) events", () => {
+  it("verifies a payouts transaction.updated event, which has no environment field", async () => {
+    const [error, event] = await verifyWebhookEvent(payoutTransactionEvent(), {
+      eventsKey: EVENTS_KEY,
+      api: "payouts",
+    });
+
+    expect(error).toBeNull();
+    expect(event?.event).toBe("transaction.updated");
+  });
+
+  it("verifies a payout.updated event", async () => {
+    const [error, event] = await verifyWebhookEvent(payoutUpdatedEvent(), {
+      eventsKey: EVENTS_KEY,
+      api: "payouts",
+    });
+
+    expect(error).toBeNull();
+    expect(event?.event).toBe("payout.updated");
+  });
+
+  it("rejects a tampered payout amount", async () => {
+    const event = payoutUpdatedEvent();
+    (event.data.payout as { amountInCents: number }).amountInCents = 999;
+
+    const [error] = await verifyWebhookEvent(event, { eventsKey: EVENTS_KEY, api: "payouts" });
+
+    expect(error).toBeInstanceOf(WompiWebhookVerificationError);
+  });
+
+  it("supports runtime-selected API options and guard composition", async () => {
+    const options: VerifyWebhookEventOptions = {
+      eventsKey: EVENTS_KEY,
+      api: "payouts",
+    };
+
+    const [error, event] = await verifyWebhookEvent(payoutTransactionEvent(), options);
+
+    expect(error).toBeNull();
+    expect(event).not.toBeNull();
+    if (!event) return;
+
+    expect(isPayoutTransactionUpdatedEvent(event) || isTransactionUpdatedEvent(event)).toBe(true);
+  });
+});
+
+describe("isPayoutTransactionUpdatedEvent", () => {
+  it("narrows payouts transaction.updated events", () => {
+    const event = payoutTransactionEvent();
+
+    expect(isPayoutTransactionUpdatedEvent(event)).toBe(true);
+
+    if (isPayoutTransactionUpdatedEvent(event)) {
+      expect(event.data.transaction.payoutId).toBe("c57a05b0-646c-11f1-8436-6ca5ce550b83");
+      expect(event.data.transaction.payee?.key).toBe("@juanperez");
+    }
+  });
+
+  it("returns false for payments-API transaction.updated events (no payoutId)", () => {
+    expect(isPayoutTransactionUpdatedEvent(transactionEvent())).toBe(false);
+  });
+
+  it("does not let payouts events pass the payments-API guard", () => {
+    expect(isTransactionUpdatedEvent(payoutTransactionEvent())).toBe(false);
+  });
+
+  it("returns false for other event types", () => {
+    expect(isPayoutTransactionUpdatedEvent(payoutUpdatedEvent())).toBe(false);
+  });
+});
+
+describe("isPayoutUpdatedEvent", () => {
+  it("narrows payout.updated events", () => {
+    const event = payoutUpdatedEvent();
+
+    expect(isPayoutUpdatedEvent(event)).toBe(true);
+
+    if (isPayoutUpdatedEvent(event)) {
+      expect(event.data.payout.status).toBe("TOTAL_PAYMENT");
+    }
+  });
+
+  it("returns false for other event types", () => {
+    expect(isPayoutUpdatedEvent(payoutTransactionEvent())).toBe(false);
+  });
+
+  it("returns false when the payout payload is malformed", () => {
+    const event = payoutUpdatedEvent();
+    event.data = { payout: { id: "x" } };
+
+    expect(isPayoutUpdatedEvent(event)).toBe(false);
   });
 });
 

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*.test-d.ts"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   test: {
     setupFiles: ["./test/setup.ts"],
     clearMocks: true,
+    typecheck: {
+      tsconfig: "./tsconfig.test.json",
+    },
     coverage: {
       clean: true,
       provider: "v8",


### PR DESCRIPTION
## Summary

- Add `wompi.breb` for BRE-B key resolution, payout creation, batch lookup, and paginated transaction lookup on Wompi's payouts v2 hosts.
- Add payouts credentials, strict request validation, typed response/status schemas, sandbox simulation support, and a minor changeset.
- Keep the existing payments webhook envelope unchanged. Payout events use `verifyWebhookEvent(payload, { eventsKey, api: "payouts" })` and dedicated typed guards.
- Document the resolve → confirm → pay → reconcile lifecycle and sandbox usage.

## Review hardening

The resolved bot threads were replayed against the official BRE-B guides and linked API schema. The final implementation requires complete bank destinations, rejects mixed payout methods and partial document pairs, covers approval/cancellation statuses, validates positive pagination, enforces recurring schedule rules, rejects sandbox-only controls in production, and models the provider's `{ page, limit, total, pages, records }` transaction envelope.

The BRE-B guides specify `/v2`; the linked Swagger document still advertises `/v1`, so the integration follows the BRE-B-specific v2 guidance while using the Swagger response schema where the narrative docs omit details.

## Verification

- `CI=1 pnpm test` — core: 175 passed, 8 credential-gated skipped; Convex: 17 passed; no type errors
- `pnpm build` — core declarations, Convex component, and strict Blume docs build pass
- Biome and `git diff --check` pass

Live payout E2E remains credential-gated because sandbox payouts credentials were not available in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added BRE-B dispersals through the `wompi.breb` API, including key resolution, payout creation, payout lookup, and paginated transaction retrieval.
  - Added support for separate payouts credentials and sandbox payout workflows.
  - Added payout webhook verification and event handling for transaction and batch updates.

- **Documentation**
  - Added BRE-B API reference and end-to-end payout examples.
  - Documented idempotency, recurring payouts, failure handling, sandbox simulations, and production setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds BRE-B payouts support to the Wompi SDK. The main changes are:

- New `wompi.breb` client methods for key resolution, payout creation, payout lookup, and transaction pagination.
- Payouts credentials, host selection, request validation, and typed payout response schemas.
- Payout webhook verification support with dedicated event guards.
- Documentation, examples, changeset, and tests for the new payouts flow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The payout destination validation now blocks the previously failing bank, mixed-method, and partial-document inputs before sending a request.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/schemas.ts | Adds BRE-B payout and webhook schemas, including stricter destination validation. |
| packages/core/src/client/breb/index.ts | Adds the BRE-B client methods and sends payout requests through the payouts API. |
| packages/core/src/server.ts | Adds payouts webhook verification and typed event guards. |
| packages/core/test/breb.test.ts | Adds coverage for BRE-B payout requests, validation, and payout lookups. |

</details>

<sub>Reviews (8): Last reviewed commit: ["docs(breb): document payout lifecycle"](https://github.com/pulgueta/wompi-node/commit/7c53d7d61302f4cb080f6b344d4a022268d746b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45869712)</sub>

<!-- /greptile_comment -->