### PR TITLE
feat(example): show checkout to supplier settlement

### DIFF
--- a/.changeset/quiet-balances-rest.md
+++ b/.changeset/quiet-balances-rest.md
@@ -1,0 +1,5 @@
+---
+"@pulgueta/wompi": patch
+---
+
+Accept payout accounts whose balance is `null` in live API responses.

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-23T06:54:30Z",
+  "title": "Design System: Wompi SDK Sandbox Story",
+  "extensions": {
+    "colorMeta": {
+      "merchant-green": {
+        "role": "primary",
+        "displayName": "Merchant Green",
+        "canonical": "oklch(47% 0.115 154)",
+        "tonalRamp": [
+          "#062516",
+          "#0A3A24",
+          "#0E5535",
+          "#126B42",
+          "#37865D",
+          "#72AA8C",
+          "#B3D5C1",
+          "#EEF7F2"
+        ]
+      },
+      "ledger-canvas": {
+        "role": "neutral",
+        "displayName": "Ledger Canvas",
+        "canonical": "oklch(96.5% 0.008 155)",
+        "tonalRamp": [
+          "#17211B",
+          "#2D3931",
+          "#526057",
+          "#7C8980",
+          "#AAB5AD",
+          "#D5DED8",
+          "#E8EEEA",
+          "#F3F6F4"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "headline": {
+        "displayName": "Product Headline",
+        "purpose": "The page title and no more than one major task heading."
+      },
+      "body": {
+        "displayName": "Interface Body",
+        "purpose": "Instructions, results, and supporting explanations."
+      }
+    },
+    "shadows": [
+      {
+        "name": "raised-action",
+        "value": "0 4px 8px rgb(18 107 66 / 0.14)",
+        "purpose": "Temporary lift for the primary checkout action only."
+      }
+    ],
+    "motion": [
+      {
+        "name": "state-change",
+        "value": "180ms cubic-bezier(0.16, 1, 0.3, 1)",
+        "purpose": "Hover, focus, and result state feedback."
+      }
+    ],
+    "breakpoints": [{ "name": "compact", "value": "640px" }, { "name": "wide", "value": "960px" }]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The next safe action in the money flow.",
+      "html": "<button class=\"ds-btn-primary\">Open sandbox checkout</button>",
+      "css": ".ds-btn-primary { border: 0; border-radius: 6px; background: #126B42; color: #FFFFFF; padding: 11px 16px; font: 650 14px/1.35 system-ui, sans-serif; transition: background 180ms cubic-bezier(0.16, 1, 0.3, 1), transform 180ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-primary:hover { background: #0E5535; } .ds-btn-primary:active { transform: translateY(1px); } .ds-btn-primary:focus-visible { outline: 3px solid #075B35; outline-offset: 2px; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "description": "A retry, refresh, or supporting action.",
+      "html": "<button class=\"ds-btn-secondary\">Refresh status</button>",
+      "css": ".ds-btn-secondary { border: 1px solid #AAB5AD; border-radius: 6px; background: #FFFFFF; color: #17211B; padding: 10px 15px; font: 650 14px/1.35 system-ui, sans-serif; transition: border-color 180ms cubic-bezier(0.16, 1, 0.3, 1), background 180ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-secondary:hover { border-color: #526057; background: #F3F6F4; } .ds-btn-secondary:focus-visible { outline: 3px solid #075B35; outline-offset: 2px; }"
+    },
+    {
+      "name": "Text Field",
+      "kind": "input",
+      "refersTo": "field",
+      "description": "A persistently labeled sandbox input.",
+      "html": "<label class=\"ds-field-label\">BRE-B alias<input class=\"ds-field\" value=\"@elias123\"></label>",
+      "css": ".ds-field-label { display: grid; gap: 6px; color: #17211B; font: 650 14px/1.35 system-ui, sans-serif; } .ds-field { border: 1px solid #AAB5AD; border-radius: 6px; background: #FFFFFF; color: #17211B; padding: 11px 12px; font: 400 16px/1.4 system-ui, sans-serif; } .ds-field:focus { border-color: #126B42; outline: 3px solid #075B35; outline-offset: 2px; }"
+    },
+    {
+      "name": "Task Surface",
+      "kind": "card",
+      "refersTo": "task-surface",
+      "description": "One stage of the payment-to-settlement flow.",
+      "html": "<section class=\"ds-task\"><h2>Settle the supplier share</h2><p>COP 40,000 through BRE-B after the order is approved.</p></section>",
+      "css": ".ds-task { border: 1px solid #D5DED8; border-radius: 14px; background: #FFFFFF; color: #17211B; padding: 24px; font-family: system-ui, sans-serif; } .ds-task h2 { margin: 0 0 8px; font-size: 18px; line-height: 1.25; } .ds-task p { margin: 0; max-width: 65ch; color: #526057; line-height: 1.55; }"
+    },
+    {
+      "name": "Verified Result",
+      "kind": "custom",
+      "description": "A durable transaction or payout outcome.",
+      "html": "<div class=\"ds-result\"><strong>Payment approved</strong><code>txn_sandbox_123</code></div>",
+      "css": ".ds-result { display: grid; gap: 6px; border-radius: 10px; background: #EEF7F2; color: #17211B; padding: 16px; font: 400 14px/1.45 system-ui, sans-serif; } .ds-result strong { color: #0E5535; } .ds-result code { overflow-wrap: anywhere; color: #526057; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Settlement Desk",
+    "overview": "A focused merchant test surface where one customer payment and one supplier settlement remain understandable at a glance. Familiar product conventions and restrained color keep attention on the SDK behavior.",
+    "keyCharacteristics": [
+      "One sequential payment-to-settlement story.",
+      "Light, cool-neutral surfaces with one merchant-green accent.",
+      "Explicit loading, success, error, and disabled states.",
+      "Technical detail presented as supporting evidence."
+    ],
+    "rules": [
+      {
+        "name": "The One Accent Rule",
+        "body": "Merchant Green is the only decorative accent. Red communicates errors and nothing else.",
+        "section": "colors"
+      },
+      {
+        "name": "The Product Scale Rule",
+        "body": "Use fixed rem sizes. No oversized fluid display type inside the task flow.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat Desk Rule",
+        "body": "Working surfaces rest on the canvas without wide ambient shadows.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do present one coherent customer-payment and supplier-settlement story.",
+      "Do accept peso amounts in the UI and convert to cents once at the integration boundary.",
+      "Do preserve IDs and prior confirmed states during retries."
+    ],
+    "donts": [
+      "Don't build generic API playgrounds that expose unrelated endpoints without a coherent task.",
+      "Don't create an imitation Wompi marketing site that competes with the official brand.",
+      "Don't use decorative fintech dashboards built from metric cards, gradients, glows, or ornamental charts.",
+      "Don't return to a payout-only form dump that makes developers assemble the end-to-end story themselves."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["apps/example/src/routes/__root.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,183 @@
+---
+name: Wompi SDK Sandbox Story
+description: A compact payment-to-settlement example for SDK evaluators.
+colors:
+  merchant-green: "#126B42"
+  merchant-green-deep: "#0E5535"
+  ledger-canvas: "#F3F6F4"
+  surface: "#FFFFFF"
+  ink: "#17211B"
+  muted-ink: "#526057"
+  divider: "#D5DED8"
+  danger: "#A93226"
+  danger-surface: "#FFF1F0"
+typography:
+  headline:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "2.25rem"
+    fontWeight: 750
+    lineHeight: 1.08
+    letterSpacing: "-0.03em"
+  title:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 700
+    lineHeight: 1.25
+  body:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.55
+  label:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 650
+    lineHeight: 1.35
+rounded:
+  sm: "6px"
+  md: "10px"
+  lg: "14px"
+  pill: "999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+  xl: "40px"
+components:
+  button-primary:
+    backgroundColor: "{colors.merchant-green}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.sm}"
+    padding: "11px 16px"
+  button-primary-hover:
+    backgroundColor: "{colors.merchant-green-deep}"
+    textColor: "{colors.surface}"
+    rounded: "{rounded.sm}"
+    padding: "11px 16px"
+  field:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    padding: "11px 12px"
+  task-surface:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "24px"
+---
+
+# Design System: Wompi SDK Sandbox Story
+
+## Overview
+
+**Creative North Star: "The Settlement Desk"**
+
+This is a focused merchant test surface, not a marketing page and not a dense operations dashboard. A developer should be able to sit down, understand the order, launch its hosted checkout, verify the result, and settle the supplier share without deciphering unrelated controls.
+
+The system uses familiar product conventions, restrained color, and concise explanatory copy. Visual hierarchy follows the actual money flow. Motion is limited to state feedback and never delays the task.
+
+**Key Characteristics:**
+
+- One sequential payment-to-settlement story.
+- Light, cool-neutral surfaces with one merchant-green accent.
+- Familiar form controls with explicit loading, success, error, and disabled states.
+- Technical detail presented as supporting evidence, not as the primary interface.
+
+## Colors
+
+The palette uses cool ledger neutrals and one established green accent, with red reserved strictly for errors.
+
+### Primary
+
+- **Merchant Green:** Primary actions, the current flow step, and verified success states.
+- **Merchant Green Deep:** Hover and pressed states for primary actions.
+
+### Neutral
+
+- **Ledger Canvas:** The page background, chosen to separate the working surface without warm-paper styling.
+- **Surface:** Forms, results, and the order summary.
+- **Ledger Ink:** Primary text and identifiers.
+- **Muted Ledger Ink:** Explanatory copy that still meets contrast requirements.
+- **Divider:** Structural boundaries between related steps.
+
+### Named Rules
+
+**The One Accent Rule.** Merchant Green is the only decorative accent. Red communicates errors and nothing else.
+
+**The State Before Color Rule.** Every status includes a text label or icon-independent message. Color may reinforce meaning but never carries it alone.
+
+## Typography
+
+**Display Font:** System UI sans-serif
+**Body Font:** System UI sans-serif
+
+**Character:** Familiar, compact, and legible. The interface should resemble a dependable developer tool rather than a campaign site.
+
+### Hierarchy
+
+- **Headline** (750, 2.25rem, 1.08): One page title, limited to two lines on narrow screens.
+- **Title** (700, 1.125rem, 1.25): Flow steps, result headings, and the order name.
+- **Body** (400, 1rem, 1.55): Explanations capped near 70 characters per line.
+- **Label** (650, 0.875rem, 1.35): Inputs, compact metadata, and button text.
+
+### Named Rules
+
+**The Product Scale Rule.** Use fixed rem sizes. No oversized fluid display type inside the task flow.
+
+## Elevation
+
+The system is flat by default. Tonal background changes and dividers establish hierarchy. A compact shadow may appear only on the hosted-checkout call to action or a temporarily raised result, never alongside an ornamental border.
+
+### Named Rules
+
+**The Flat Desk Rule.** Working surfaces rest on the canvas without wide ambient shadows. If a section looks like a floating marketing card, remove the shadow.
+
+## Components
+
+### Buttons
+
+- **Shape:** Firm, gently rounded corners (6px).
+- **Primary:** Merchant Green with white text and compact 11px by 16px padding.
+- **Hover / Focus:** Deepen the green on hover; use a visible three-pixel focus ring with two-pixel separation.
+- **Secondary:** White or transparent surface with an ink divider border. Never gray text on gray fill.
+
+### Cards / Containers
+
+- **Corner Style:** Soft product radius (14px maximum).
+- **Background:** White on the Ledger Canvas.
+- **Shadow Strategy:** Flat by default, using spacing and one divider rather than ambient shadows.
+- **Border:** One subtle full border only when it clarifies grouping.
+- **Internal Padding:** 24px desktop, 16px narrow screens.
+
+### Inputs / Fields
+
+- **Style:** White background, one neutral border, 6px radius, and persistent labels above every field.
+- **Focus:** Merchant Green ring with enough separation from the border.
+- **Error / Disabled:** Error text sits directly below the field. Disabled controls remain readable and explain the missing prerequisite nearby.
+
+### Navigation
+
+- Use one compact horizontal step indicator for Order, Checkout, and Settlement. On narrow screens it becomes a vertical progress list without hiding labels.
+
+### Transaction Result
+
+- Preserve the transaction or payout ID, explicit status, amount in normal COP, and a recovery action. Never clear the last confirmed result while a retry begins.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** present one coherent customer-payment and supplier-settlement story.
+- **Do** mark browser, server, Wompi-hosted, and webhook responsibilities in plain language.
+- **Do** accept peso amounts in the UI and convert to cents once at the integration boundary.
+- **Do** preserve IDs and prior confirmed states during retries.
+- **Do** use the documented sandbox aliases and card values as test data, never as credentials.
+
+### Don't:
+
+- **Don't** build generic API playgrounds that expose unrelated endpoints without a coherent task.
+- **Don't** create an imitation Wompi marketing site that competes with the official brand.
+- **Don't** use decorative fintech dashboards built from metric cards, gradients, glows, or ornamental charts.
+- **Don't** return to a payout-only form dump that makes developers assemble the end-to-end story themselves.
+- **Don't** use gradient text, glassmorphism, side-stripe alerts, oversized radii, or wide ghost-card shadows.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,36 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+JavaScript and TypeScript developers, solution engineers, and technical evaluators testing the unofficial `@pulgueta/wompi` SDK in Wompi's Colombia sandbox. They need to understand the server and browser boundaries of a real payment flow before adapting it to their own application.
+
+## Product Purpose
+
+Provide one runnable, short sandbox scenario that demonstrates money entering through regular Wompi Checkout and leaving through a confirmed BRE-B payout. Success means a developer can see which SDK feature performs each operation, test both successful and failed sandbox states, and recover from errors without reading a generic API playground.
+
+## Brand Personality
+
+Credible, concise, transparent. The interface should feel calm enough for careful financial testing, direct enough for a developer scanning code and results, and honest about sandbox limitations.
+
+## Anti-references
+
+- Generic API playgrounds that expose unrelated endpoints without a coherent task.
+- An imitation Wompi marketing site that competes with the official brand.
+- Decorative fintech dashboards built from metric cards, gradients, glows, or ornamental charts.
+- A payout-only form dump that makes developers assemble the end-to-end story themselves.
+
+## Design Principles
+
+1. **Tell one complete money story.** A customer purchase and its supplier settlement belong in the same short flow.
+2. **Expose the SDK boundary.** Identify what runs in the browser, what stays on the server, and what Wompi hosts.
+3. **Make sandbox safety explicit.** Never imply that documented aliases or card numbers are real credentials or move real money.
+4. **Show outcomes, not requests.** Preserve transaction IDs, payout IDs, final states, and recovery actions after every operation.
+5. **Prefer live behavior over assumptions.** Treat current Wompi responses and signed status checks as the source of truth.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.2 AA. All actions and status changes must be keyboard accessible, screen-reader announced, and understandable without relying on color alone. Forms need persistent labels and actionable errors. Responsive layouts must remain usable at narrow widths, and all non-essential motion must respect reduced-motion preferences.

--- a/apps/example/.env.example
+++ b/apps/example/.env.example
@@ -1,3 +1,10 @@
+# Public key used by the sandbox Web Checkout and transaction status lookup.
+WOMPI_PUBLIC_KEY=
+# Integrity key used only by the server to sign sandbox Web Checkout URLs.
+WOMPI_INTEGRITY_KEY=
+# Exact public origin used for hosted Checkout redirects (required for a tunnel).
+WOMPI_EXAMPLE_ORIGIN=http://localhost:3000
+
 # API key from the Payouts section of the Wompi dashboard.
 WOMPI_PAYOUTS_API_KEY=
 # User principal ID paired with the Payouts API key.

--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -1,68 +1,81 @@
-# Wompi payouts example
+# Wompi checkout and settlement example
 
-This TanStack Start app demonstrates the sandbox payout features in
+This TanStack Start app runs one Colombia sandbox order through both sides of
 `@pulgueta/wompi`:
 
-- list origin accounts and their balances;
-- resolve a masked BRE-B beneficiary before sending funds;
-- create one BRE-B or bank-account dispersion;
-- refresh the resulting payout status; and
-- verify and narrow signed payout webhook events on the server.
+1. create a server-signed Wompi Web Checkout for a COP 49,500 order;
+2. verify the transaction returned by Wompi; and
+3. settle the COP 40,000 supplier share through a resolved BRE-B key or a bank
+   or digital-wallet account.
 
-All Wompi credentials and SDK calls stay on the server. The browser only calls
-TanStack Start server functions that return small serializable DTOs.
+Checkout integrity and Payouts credentials stay on the server. The browser
+receives narrow serializable DTOs and never sees a secret key.
 
-> This is a local sandbox demo. Its payout server functions intentionally have
-> no application authentication and reject calls outside development mode. Do
-> not remove that guard or deploy it publicly without adding authorization for
-> every payout server function.
+Before creating a payout, the server verifies a signed order proof and fetches
+the Wompi transaction again. The transaction must be `APPROVED` and match the
+exact reference, COP currency, and amount issued for this browser flow. A
+deterministic settlement reference and idempotency key limit the example to one
+supplier settlement attempt per checkout transaction.
+
+> This is a local sandbox demo. Its server functions are unauthenticated and
+> reject calls outside development mode. The signed order proof protects the
+> tunneled payout flow, but it is not a replacement for application
+> authorization or durable order/payout persistence in production.
 
 ## Setup
 
-From the monorepo root, copy the environment template and add sandbox Payouts
-credentials from the Wompi dashboard:
+Copy the environment template, then add the sandbox keys from the Wompi
+dashboard:
 
 ```bash
-cp apps/example/.env.example apps/example/.env
+cp apps/example/.env.example apps/example/.env.local
 ```
 
-Then install the workspace and start the example:
+- `WOMPI_PUBLIC_KEY` and `WOMPI_INTEGRITY_KEY` come from the regular Payments
+  integration.
+- `WOMPI_PAYOUTS_API_KEY`, `WOMPI_PAYOUTS_USER_PRINCIPAL_ID`, and
+  `WOMPI_PAYOUTS_EVENTS_KEY` come from **Pagos a Terceros**.
+- `WOMPI_EXAMPLE_ORIGIN` must be the exact public HTTPS tunnel origin when the
+  hosted Checkout needs to return from another browser.
+
+Install and run from the monorepo root:
 
 ```bash
 pnpm install
-pnpm turbo run dev --filter=wompi-example
+pnpm --filter wompi-example dev
 ```
 
-The app runs at `http://localhost:3000` by default.
+The app runs at `http://localhost:3000` by default. A public HTTPS tunnel is
+needed for the hosted Checkout redirect to return to a remote browser.
 
-## Sandbox BRE-B keys
+## Sandbox data
 
-Successful resolutions:
+Approved Web Checkout card:
 
-| Key | Key type | Financial entity |
-| --- | --- | --- |
-| `ecolon@wompi.com` | `MAIL` | BANCOLOMBIA |
-| `3001234567` | `PHONE` | BANCO POPULAR |
-| `1020304050` | `IDENTIFICATION` | BANCO POPULAR |
-| `@elias123` | `ALPHANUMERIC` | BANCO DAVIVIENDA |
+```text
+4242 4242 4242 4242
+Any future expiry
+Any three-digit CVC
+```
 
-Error simulations:
+The primary BRE-B example uses `@elias123`. Other successful keys include
+`ecolon@wompi.com`, `3001234567`, `1020304050`, `B00012345`, and `900123456`.
 
-| Key | Result |
-| --- | --- |
-| `noexiste@test.com` | `EXC_034` — key not found |
-| `inactiva@test.com` | `EXC_035` — inactive key |
-| `timeout@test.com` | `EXC_037` — resolution timeout |
-| `error@test.com` | `EXC_036` — service unavailable |
+The bank or wallet alternative loads the live sandbox catalogue. It explicitly
+sends the supplier profile's `personType`, legal identity, beneficiary email,
+and transaction reference because Wompi's OpenAPI and prose documentation
+disagree about which are required. The operator only chooses the institution,
+conditional account type, and account or wallet number before a review step.
 
 ## Webhook
 
-Configure the Payouts events URL to target:
+Configure Payouts events to target:
 
 ```text
 /api/payouts-webhook
 ```
 
-The handler verifies the raw request body with
-`WOMPI_PAYOUTS_EVENTS_KEY`, rejects invalid signatures with HTTP 403, and logs
-the ID and status of verified `payout.updated` and `transaction.updated` events.
+The handler verifies the raw body with `WOMPI_PAYOUTS_EVENTS_KEY`, rejects bad
+signatures, and logs the ID and status of verified payout events. The example
+polls status in the UI; a production application should persist signed webhook
+results as its durable source of truth.

--- a/apps/example/src/lib/checkout-storage.test.ts
+++ b/apps/example/src/lib/checkout-storage.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { readCheckoutBinding, saveCheckoutBinding } from "./checkout-storage";
+
+describe("checkout reference storage", () => {
+  it("restores the exact launched order reference after returning from Wompi", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    const binding = {
+      reference: "order-barber-kit-launched",
+      orderProof: "signed-order-proof",
+    };
+    saveCheckoutBinding(storage, binding);
+
+    expect(readCheckoutBinding(storage)).toEqual(binding);
+  });
+});

--- a/apps/example/src/lib/checkout-storage.ts
+++ b/apps/example/src/lib/checkout-storage.ts
@@ -1,0 +1,36 @@
+type CheckoutStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type CheckoutBinding = {
+  reference: string;
+  orderProof: string;
+};
+
+const CHECKOUT_BINDING_STORAGE_KEY = "wompi-sdk-demo:checkout-binding";
+
+export function readCheckoutBinding(
+  storage: CheckoutStorage,
+): CheckoutBinding | null {
+  try {
+    const value = storage.getItem(CHECKOUT_BINDING_STORAGE_KEY);
+    if (!value) return null;
+
+    const parsed = JSON.parse(value) as Partial<CheckoutBinding>;
+    if (
+      typeof parsed.reference === "string" &&
+      typeof parsed.orderProof === "string"
+    ) {
+      return { reference: parsed.reference, orderProof: parsed.orderProof };
+    }
+  } catch {
+    // Treat a corrupt demo entry as missing checkout context.
+  }
+
+  return null;
+}
+
+export function saveCheckoutBinding(
+  storage: CheckoutStorage,
+  binding: CheckoutBinding,
+) {
+  storage.setItem(CHECKOUT_BINDING_STORAGE_KEY, JSON.stringify(binding));
+}

--- a/apps/example/src/lib/payout-presentation.test.ts
+++ b/apps/example/src/lib/payout-presentation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getPayoutPresentation } from "./payout-presentation";
+
+describe("payout presentation", () => {
+  it("never presents a failed transfer as submitted or paid", () => {
+    expect(
+      getPayoutPresentation(
+        { failed: 0 },
+        { status: "TOTAL_PAYMENT", transactionStatus: "FAILED" },
+      ),
+    ).toEqual({ visibleStatus: "FAILED", title: "Payout failed" });
+  });
+
+  it("surfaces an immediately failed single-transfer batch", () => {
+    expect(getPayoutPresentation({ failed: 1 }, null)).toEqual({
+      visibleStatus: "FAILED",
+      title: "Payout failed",
+    });
+  });
+
+  it("marks a completed payout as paid", () => {
+    expect(
+      getPayoutPresentation({ failed: 0 }, { status: "TOTAL_PAYMENT" }),
+    ).toEqual({ visibleStatus: "TOTAL_PAYMENT", title: "Supplier paid" });
+  });
+});

--- a/apps/example/src/lib/payout-presentation.ts
+++ b/apps/example/src/lib/payout-presentation.ts
@@ -1,0 +1,26 @@
+const FAILED_STATUSES = new Set(["DECLINED", "ERROR", "FAILED", "REJECTED"]);
+const SUCCESS_STATUSES = new Set([
+  "APPROVED",
+  "COMPLETED",
+  "SUCCESS",
+  "TOTAL_PAYMENT",
+]);
+
+export function getPayoutPresentation(
+  result: { failed?: number },
+  status: { status: string; transactionStatus?: string } | null,
+) {
+  const reportedStatus = status?.transactionStatus ?? status?.status;
+  const failed =
+    (result.failed ?? 0) > 0 || FAILED_STATUSES.has(reportedStatus ?? "");
+  const visibleStatus = failed ? "FAILED" : (reportedStatus ?? "SUBMITTED");
+
+  return {
+    visibleStatus,
+    title: failed
+      ? "Payout failed"
+      : SUCCESS_STATUSES.has(visibleStatus)
+        ? "Supplier paid"
+        : "Payout submitted",
+  };
+}

--- a/apps/example/src/routes/__root.tsx
+++ b/apps/example/src/routes/__root.tsx
@@ -13,7 +13,12 @@ export const Route = createRootRoute({
         content: "width=device-width, initial-scale=1",
       },
       {
-        title: "Wompi payouts sandbox demo",
+        title: "Checkout to settlement · Wompi SDK sandbox",
+      },
+      {
+        name: "description",
+        content:
+          "A runnable Wompi sandbox order using hosted Checkout and BRE-B supplier settlement.",
       },
     ],
     links: [

--- a/apps/example/src/routes/index.tsx
+++ b/apps/example/src/routes/index.tsx
@@ -1,57 +1,559 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 
+import {
+  readCheckoutBinding,
+  saveCheckoutBinding,
+} from "#/lib/checkout-storage";
+import type { CheckoutBinding } from "#/lib/checkout-storage";
+import { getPayoutPresentation } from "#/lib/payout-presentation";
+import {
+  createCheckoutSession,
+  getCheckoutTransaction,
+} from "#/server/checkout";
+import type { CheckoutTransactionDto } from "#/server/checkout";
 import {
   createDispersion,
   getPayoutStatus,
   listAccounts,
   listBanks,
   resolveKey,
+  SETTLEMENT_AMOUNT_IN_CENTS,
+  SUPPLIER_EMAIL,
+  SUPPLIER_LEGAL_ID,
+  SUPPLIER_LEGAL_ID_TYPE,
+  SUPPLIER_NAME,
+  SUPPLIER_PERSON_TYPE,
 } from "#/server/payouts";
 import type {
   AccountDto,
   BankDto,
+  CreateResultDto,
   KeyResolutionDto,
+  PayoutRail,
   PayoutStatusDto,
-  ResolveKeyInput,
 } from "#/server/payouts";
 
-const KEY_TYPES = [
-  "ALPHANUMERIC",
-  "MAIL",
-  "PHONE",
-  "IDENTIFICATION",
-  "ESTABLISHMENT_CODE",
-] as const;
+const ORDER_AMOUNT_IN_CENTS = 4_950_000;
+const ORDER_NAME = "Barber essentials kit";
+const CUSTOMER_NAME = "Laura Mendoza";
+const CUSTOMER_EMAIL = "laura@example.com";
+const BREB_TEST_KEY = "@elias123";
 
-const LEGAL_ID_TYPES = ["CC", "CE", "NIT", "PP", "TI", "DNI"] as const;
-const ACCOUNT_TYPES = ["AHORROS", "CORRIENTE"] as const;
+const ACCOUNT_TYPES = ["AHORROS", "CORRIENTE", "DEPOSITO_ELECTRONICO"] as const;
+
+type SettlementRail = "breb" | "bank";
+type AccountType = (typeof ACCOUNT_TYPES)[number];
+type PayoutResult = CreateResultDto & {
+  payoutId: string;
+  rail: PayoutRail;
+};
 
 const copFormatter = new Intl.NumberFormat("es-CO", {
   style: "currency",
   currency: "COP",
+  maximumFractionDigits: 0,
 });
 
-export const Route = createFileRoute("/")({ component: Home });
+export const Route = createFileRoute("/")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    id: typeof search.id === "string" ? search.id : undefined,
+  }),
+  component: Home,
+});
 
-function formatBalance(balanceInCents: number | undefined) {
-  return balanceInCents === undefined
-    ? "Balance unavailable"
-    : copFormatter.format(balanceInCents / 100);
+function formatCents(value: number | null | undefined) {
+  return value == null ? "Not reported" : copFormatter.format(value / 100);
 }
 
-function getRequestError(error: unknown) {
+function formatDate(value: string | null | undefined) {
+  if (!value) return null;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat("en", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+}
+
+function getErrorMessage(error: unknown) {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
   return error instanceof Error
     ? error.message
     : "The request could not be completed.";
 }
 
-function Home() {
-  const [accounts, setAccounts] = useState<AccountDto[]>([]);
-  const [accountsError, setAccountsError] = useState<string | null>(null);
-  const [accountsLoading, setAccountsLoading] = useState(false);
+function statusTone(status: string) {
+  if (["APPROVED", "TOTAL_PAYMENT", "SUCCESS", "COMPLETED"].includes(status)) {
+    return "success";
+  }
 
-  async function handleLoadAccounts() {
+  if (["DECLINED", "ERROR", "FAILED", "REJECTED"].includes(status)) {
+    return "danger";
+  }
+
+  return "pending";
+}
+
+function Home() {
+  const { id: returnedTransactionId } = Route.useSearch();
+  const [transaction, setTransaction] = useState<CheckoutTransactionDto | null>(
+    null,
+  );
+  const [transactionLoading, setTransactionLoading] = useState(false);
+  const [transactionError, setTransactionError] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const [checkoutBinding, setCheckoutBinding] =
+    useState<CheckoutBinding | null>(null);
+  const [checkoutBindingReady, setCheckoutBindingReady] = useState(false);
+  const transactionRequestId = useRef(0);
+  const checkoutApproved = transaction?.status === "APPROVED";
+
+  async function refreshTransaction(
+    transactionId: string,
+    binding: CheckoutBinding,
+  ) {
+    const requestId = ++transactionRequestId.current;
+    setTransactionLoading(true);
+    setTransactionError(null);
+
+    try {
+      const result = await getCheckoutTransaction({
+        data: {
+          transactionId,
+          expectedReference: binding.reference,
+          orderProof: binding.orderProof,
+        },
+      });
+
+      if (requestId !== transactionRequestId.current) return;
+
+      if (result.error) {
+        setTransaction(null);
+        setTransactionError(getErrorMessage(result.error));
+      } else if (result.data) {
+        setTransaction(result.data);
+      } else {
+        setTransaction(null);
+        setTransactionError("Wompi did not return a transaction.");
+      }
+    } catch (error) {
+      if (requestId === transactionRequestId.current) {
+        setTransaction(null);
+        setTransactionError(getErrorMessage(error));
+      }
+    } finally {
+      if (requestId === transactionRequestId.current) {
+        setTransactionLoading(false);
+      }
+    }
+  }
+
+  useEffect(() => {
+    setCheckoutBinding(readCheckoutBinding(window.sessionStorage));
+    setCheckoutBindingReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!returnedTransactionId || !checkoutBindingReady) return;
+
+    if (!checkoutBinding) {
+      setTransaction(null);
+      setTransactionError(
+        "This browser no longer has the launched order reference. Start another checkout.",
+      );
+      return;
+    }
+
+    void refreshTransaction(returnedTransactionId, checkoutBinding);
+    return () => {
+      transactionRequestId.current += 1;
+    };
+  }, [returnedTransactionId, checkoutBindingReady, checkoutBinding]);
+
+  async function launchCheckout() {
+    setLaunching(true);
+    setLaunchError(null);
+
+    try {
+      const result = await createCheckoutSession();
+
+      if (result.error) {
+        setLaunchError(getErrorMessage(result.error));
+      } else if (result.data) {
+        const binding = {
+          reference: result.data.reference,
+          orderProof: result.data.orderProof,
+        };
+        saveCheckoutBinding(window.sessionStorage, binding);
+        setCheckoutBinding(binding);
+        window.location.assign(result.data.checkoutUrl);
+      } else {
+        setLaunchError("Wompi did not return a checkout URL.");
+      }
+    } catch (error) {
+      setLaunchError(getErrorMessage(error));
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  return (
+    <>
+      <header className="topbar">
+        <a className="wordmark" href="/">
+          Wompi SDK
+        </a>
+        <span className="environment-badge">Sandbox</span>
+      </header>
+
+      <main className="workspace">
+        <header className="page-intro">
+          <p className="eyebrow">Checkout to settlement</p>
+          <h1>One order, both sides of the SDK.</h1>
+          <p>
+            Charge the customer with hosted Checkout, then settle the supplier
+            through BRE-B.
+          </p>
+        </header>
+
+        <FlowProgress
+          checkoutStatus={transaction?.status ?? null}
+          settlementAvailable={checkoutApproved}
+        />
+
+        <div className="commerce-layout">
+          <div className="flow-column">
+            <section className="task-step" aria-labelledby="checkout-heading">
+              <StepHeading
+                number="1"
+                title="Customer checkout"
+                id="checkout-heading"
+                meta={checkoutApproved ? "Approved" : "COP 49,500"}
+              />
+
+              {returnedTransactionId ? (
+                <CheckoutResult
+                  transactionId={returnedTransactionId}
+                  transaction={transaction}
+                  loading={transactionLoading}
+                  error={transactionError}
+                  onRefresh={() => {
+                    if (checkoutBinding) {
+                      void refreshTransaction(
+                        returnedTransactionId,
+                        checkoutBinding,
+                      );
+                    }
+                  }}
+                  onRestart={launchCheckout}
+                  restarting={launching}
+                />
+              ) : (
+                <div className="checkout-action">
+                  <div>
+                    <h3>Pay with Wompi Checkout</h3>
+                    <p>
+                      The SDK signs the order on the server. Payment details
+                      stay on Wompi's hosted page.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={launchCheckout}
+                    disabled={launching}
+                  >
+                    {launching ? "Opening checkout…" : "Open checkout"}
+                  </button>
+                </div>
+              )}
+
+              {!returnedTransactionId ? <SandboxCardData /> : null}
+
+              {launchError ? (
+                <InlineMessage tone="error">{launchError}</InlineMessage>
+              ) : null}
+            </section>
+
+            <section
+              className={`task-step${checkoutApproved ? "" : " task-step-locked"}`}
+              aria-labelledby="settlement-heading"
+            >
+              <StepHeading
+                number="2"
+                title="Supplier settlement"
+                id="settlement-heading"
+                meta={
+                  checkoutApproved
+                    ? formatCents(SETTLEMENT_AMOUNT_IN_CENTS)
+                    : "After approval"
+                }
+              />
+
+              {checkoutApproved && transaction && checkoutBinding ? (
+                <SettlementWorkspace
+                  transaction={transaction}
+                  orderProof={checkoutBinding.orderProof}
+                />
+              ) : (
+                <div className="locked-copy">
+                  <span className="lock-mark" aria-hidden="true">
+                    2
+                  </span>
+                  <p>Approve the checkout to unlock supplier settlement.</p>
+                </div>
+              )}
+            </section>
+          </div>
+
+          <OrderSummary transaction={transaction} />
+        </div>
+      </main>
+    </>
+  );
+}
+
+function StepHeading({
+  number,
+  title,
+  id,
+  meta,
+}: {
+  number: string;
+  title: string;
+  id: string;
+  meta: string;
+}) {
+  return (
+    <div className="step-heading">
+      <div>
+        <span className="step-number" aria-hidden="true">
+          {number}
+        </span>
+        <h2 id={id}>{title}</h2>
+      </div>
+      <span className="step-meta">{meta}</span>
+    </div>
+  );
+}
+
+function FlowProgress({
+  checkoutStatus,
+  settlementAvailable,
+}: {
+  checkoutStatus: string | null;
+  settlementAvailable: boolean;
+}) {
+  const checkoutComplete = checkoutStatus === "APPROVED";
+
+  return (
+    <ol className="flow-progress" aria-label="Order progress">
+      <li className="is-complete">
+        <span>Order</span>
+        <small>Ready</small>
+      </li>
+      <li
+        className={checkoutComplete ? "is-complete" : "is-current"}
+        aria-current={checkoutComplete ? undefined : "step"}
+      >
+        <span>Checkout</span>
+        <small>{checkoutStatus ?? "Next"}</small>
+      </li>
+      <li
+        className={settlementAvailable ? "is-current" : ""}
+        aria-current={settlementAvailable ? "step" : undefined}
+      >
+        <span>Settlement</span>
+        <small>{settlementAvailable ? "Ready" : "Locked"}</small>
+      </li>
+    </ol>
+  );
+}
+
+function SandboxCardData() {
+  return (
+    <div className="sandbox-data" aria-label="Approved sandbox card">
+      <div>
+        <span>Approved test card</span>
+        <code>4242 4242 4242 4242</code>
+      </div>
+      <p>Any future expiry · Any 3-digit CVC</p>
+    </div>
+  );
+}
+
+function CheckoutResult({
+  transactionId,
+  transaction,
+  loading,
+  error,
+  onRefresh,
+  onRestart,
+  restarting,
+}: {
+  transactionId: string;
+  transaction: CheckoutTransactionDto | null;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+  onRestart: () => void;
+  restarting: boolean;
+}) {
+  if (loading && !transaction) {
+    return (
+      <p className="loading-state" role="status">
+        Checking the Wompi transaction…
+      </p>
+    );
+  }
+
+  return (
+    <div className="result-stack" aria-live="polite">
+      {error ? <InlineMessage tone="error">{error}</InlineMessage> : null}
+
+      {transaction ? (
+        <div className="result-panel">
+          <div className="result-title-row">
+            <div>
+              <p className="result-kicker">Payment result</p>
+              <h3>
+                {transaction.status === "APPROVED"
+                  ? "Customer payment approved"
+                  : `Payment ${transaction.status.toLowerCase()}`}
+              </h3>
+            </div>
+            <StatusBadge status={transaction.status} />
+          </div>
+
+          <dl className="result-facts">
+            <div>
+              <dt>Amount</dt>
+              <dd>{formatCents(transaction.amountInCents)}</dd>
+            </div>
+            <div>
+              <dt>Method</dt>
+              <dd>{transaction.paymentMethodType ?? "Not reported"}</dd>
+            </div>
+          </dl>
+
+          {transaction.statusMessage ? (
+            <p className="supporting-copy">{transaction.statusMessage}</p>
+          ) : null}
+
+          <div className="result-actions">
+            <button
+              className="secondary-button"
+              type="button"
+              onClick={onRefresh}
+              disabled={loading}
+            >
+              {loading ? "Refreshing…" : "Refresh status"}
+            </button>
+            {transaction.status !== "APPROVED" ? (
+              <button type="button" onClick={onRestart} disabled={restarting}>
+                {restarting ? "Opening…" : "Try another checkout"}
+              </button>
+            ) : null}
+          </div>
+
+          <TechnicalDetails
+            rows={[
+              ["Transaction ID", transaction.id],
+              ["Reference", transaction.reference],
+              ["Created", formatDate(transaction.createdAt) ?? "Not reported"],
+            ]}
+          />
+        </div>
+      ) : (
+        <div className="result-actions">
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={onRefresh}
+            disabled={loading}
+          >
+            {loading ? "Refreshing…" : "Try status again"}
+          </button>
+          <button type="button" onClick={onRestart} disabled={restarting}>
+            {restarting ? "Opening…" : "Start another checkout"}
+          </button>
+        </div>
+      )}
+
+      {!transaction && !error ? (
+        <p className="supporting-copy">Transaction {transactionId}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function SettlementWorkspace({
+  transaction,
+  orderProof,
+}: {
+  transaction: CheckoutTransactionDto;
+  orderProof: string;
+}) {
+  const [rail, setRail] = useState<SettlementRail>("breb");
+  const [accounts, setAccounts] = useState<AccountDto[]>([]);
+  const [accountId, setAccountId] = useState("");
+  const [accountsLoading, setAccountsLoading] = useState(true);
+  const [accountsError, setAccountsError] = useState<string | null>(null);
+  const [banks, setBanks] = useState<BankDto[]>([]);
+  const [banksLoading, setBanksLoading] = useState(false);
+  const [banksError, setBanksError] = useState<string | null>(null);
+  const [key, setKey] = useState(BREB_TEST_KEY);
+  const [resolution, setResolution] = useState<KeyResolutionDto | null>(null);
+  const [brebRecipientConfirmed, setBrebRecipientConfirmed] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [bankId, setBankId] = useState("");
+  const [accountType, setAccountType] = useState<AccountType>("AHORROS");
+  const [accountNumber, setAccountNumber] = useState("");
+  const [bankReview, setBankReview] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createWarning, setCreateWarning] = useState<string | null>(null);
+  const [payoutResult, setPayoutResult] = useState<PayoutResult | null>(null);
+  const [payoutStatus, setPayoutStatus] = useState<PayoutStatusDto | null>(
+    null,
+  );
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const resolveRequestId = useRef(0);
+  const statusRequestId = useRef(0);
+  const bankReviewHeadingRef = useRef<HTMLHeadingElement>(null);
+  const storageKey = `wompi-sdk-demo:settlement:${transaction.id}`;
+  const selectedAccount = accounts.find((account) => account.id === accountId);
+  const sourceAccountInsufficient = Boolean(
+    selectedAccount?.balanceInCents != null &&
+      selectedAccount.balanceInCents < SETTLEMENT_AMOUNT_IN_CENTS,
+  );
+  const sourceAccountBalanceUnavailable = Boolean(
+    selectedAccount && selectedAccount.balanceInCents == null,
+  );
+  const sourceAccountBlocked =
+    sourceAccountInsufficient || sourceAccountBalanceUnavailable;
+  const selectedBank = banks.find((bank) => bank.id === bankId);
+  const resolutionConfirmed = Boolean(
+    resolution?.holderName.trim() &&
+      (resolution.financialEntityName?.trim() ||
+        resolution.financialEntityCode?.trim()) &&
+      (resolution.keyValue.trim() || key.trim()),
+  );
+
+  async function loadSourceAccounts() {
     setAccountsLoading(true);
     setAccountsError(null);
 
@@ -60,439 +562,33 @@ function Home() {
 
       if (result.error) {
         setAccounts([]);
-        setAccountsError(result.error);
-      } else if (result.data) {
+        setAccountId("");
+        setAccountsError(getErrorMessage(result.error));
+      } else if (result.data?.length) {
         setAccounts(result.data);
+        const fundedAccount = result.data.find(
+          (account) =>
+            account.balanceInCents != null &&
+            account.balanceInCents >= SETTLEMENT_AMOUNT_IN_CENTS,
+        );
+        setAccountId(fundedAccount?.id ?? "");
       } else {
-        setAccountsError("Wompi did not return any account data.");
+        setAccounts([]);
+        setAccountId("");
+        setAccountsError("No active payout account is available.");
       }
     } catch (error) {
       setAccounts([]);
-      setAccountsError(getRequestError(error));
+      setAccountId("");
+      setAccountsError(getErrorMessage(error));
     } finally {
       setAccountsLoading(false);
     }
   }
 
-  return (
-    <main>
-      <header className="page-header">
-        <p className="eyebrow">Wompi sandbox</p>
-        <h1>Payouts example</h1>
-        <p>
-          Load an origin account, resolve a BRE-B key, and create a single bank
-          or BRE-B dispersion with the <code>@pulgueta/wompi</code> SDK.
-        </p>
-      </header>
+  async function loadDestinationBanks() {
+    if (banksLoading || banks.length > 0) return;
 
-      <section aria-labelledby="accounts-heading">
-        <div className="section-heading">
-          <div>
-            <h2 id="accounts-heading">Accounts</h2>
-            <p>Origin accounts available to fund a payout.</p>
-          </div>
-          <button
-            type="button"
-            onClick={handleLoadAccounts}
-            disabled={accountsLoading}
-          >
-            {accountsLoading ? "Loading…" : "Load accounts"}
-          </button>
-        </div>
-
-        {accountsError ? (
-          <p className="error" role="alert">
-            {accountsError}
-          </p>
-        ) : null}
-
-        {accounts.length > 0 ? (
-          <ul className="account-list">
-            {accounts.map((account) => (
-              <li key={account.id}>
-                <code>{account.id}</code>
-                <span>{formatBalance(account.balanceInCents)}</span>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="empty-state">No accounts loaded.</p>
-        )}
-      </section>
-
-      <BrebDispersion accounts={accounts} />
-      <BankDispersion accounts={accounts} />
-    </main>
-  );
-}
-
-function AccountSelect({ accounts }: { accounts: AccountDto[] }) {
-  return (
-    <label>
-      Origin account
-      <select name="accountId" required disabled={accounts.length === 0}>
-        <option value="">Select an account</option>
-        {accounts.map((account) => (
-          <option key={account.id} value={account.id}>
-            {account.id} — {formatBalance(account.balanceInCents)}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
-function PayoutResult({
-  payoutId,
-  status,
-  error,
-  refreshing,
-  onRefresh,
-}: {
-  payoutId: string;
-  status: PayoutStatusDto | null;
-  error: string | null;
-  refreshing: boolean;
-  onRefresh: () => void;
-}) {
-  return (
-    <div className="payout-result" aria-live="polite">
-      <p>
-        <strong>Payout ID</strong>
-        <code>{payoutId}</code>
-      </p>
-      <button type="button" onClick={onRefresh} disabled={refreshing}>
-        {refreshing ? "Refreshing…" : "Refresh status"}
-      </button>
-
-      {error ? (
-        <p className="error" role="alert">
-          {error}
-        </p>
-      ) : null}
-
-      {status ? (
-        <dl className="status-details">
-          <div>
-            <dt>Status</dt>
-            <dd>{status.status}</dd>
-          </div>
-          {status.reference ? (
-            <div>
-              <dt>Reference</dt>
-              <dd>{status.reference}</dd>
-            </div>
-          ) : null}
-          {status.createdAt ? (
-            <div>
-              <dt>Created</dt>
-              <dd>{status.createdAt}</dd>
-            </div>
-          ) : null}
-        </dl>
-      ) : null}
-    </div>
-  );
-}
-
-function BrebDispersion({ accounts }: { accounts: AccountDto[] }) {
-  type KeyType = NonNullable<ResolveKeyInput["keyType"]>;
-  type ConfirmedResolution = {
-    resolution: KeyResolutionDto;
-    key: string;
-    keyType?: KeyType;
-  };
-
-  const [key, setKey] = useState("");
-  const [keyType, setKeyType] = useState<KeyType | "">("");
-  const [confirmedResolution, setConfirmedResolution] =
-    useState<ConfirmedResolution | null>(null);
-  const [resolveError, setResolveError] = useState<string | null>(null);
-  const [resolving, setResolving] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [payoutId, setPayoutId] = useState<string | null>(null);
-  const [status, setStatus] = useState<PayoutStatusDto | null>(null);
-  const [statusError, setStatusError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const resolveRequestId = useRef(0);
-  const statusRequestId = useRef(0);
-  const resolution = confirmedResolution?.resolution ?? null;
-
-  async function handleResolve(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const requestId = ++resolveRequestId.current;
-    const requestedKey = key.trim();
-    const requestedKeyType = keyType || undefined;
-    setResolving(true);
-    setResolveError(null);
-    setConfirmedResolution(null);
-
-    const data: ResolveKeyInput = {
-      key: requestedKey,
-      ...(requestedKeyType ? { keyType: requestedKeyType } : {}),
-    };
-
-    try {
-      const result = await resolveKey({ data });
-
-      if (requestId !== resolveRequestId.current) return;
-
-      if (result.error) {
-        setResolveError(result.error);
-      } else if (result.data) {
-        setConfirmedResolution({
-          resolution: result.data,
-          key: requestedKey,
-          ...(requestedKeyType ? { keyType: requestedKeyType } : {}),
-        });
-      } else {
-        setResolveError("Wompi did not return a key resolution.");
-      }
-    } catch (error) {
-      if (requestId === resolveRequestId.current) {
-        setResolveError(getRequestError(error));
-      }
-    } finally {
-      if (requestId === resolveRequestId.current) {
-        setResolving(false);
-      }
-    }
-  }
-
-  async function handleCreate(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!confirmedResolution) return;
-
-    const formData = new FormData(event.currentTarget);
-
-    statusRequestId.current += 1;
-    setCreating(true);
-    setRefreshing(false);
-    setCreateError(null);
-    setPayoutId(null);
-    setStatus(null);
-    setStatusError(null);
-
-    try {
-      const result = await createDispersion({
-        data: {
-          accountId: String(formData.get("accountId")),
-          reference: String(formData.get("reference")).trim(),
-          transaction: {
-            key: confirmedResolution.key,
-            name: String(formData.get("name")).trim(),
-            email: String(formData.get("email")).trim(),
-            amount: Number(formData.get("amount")),
-          },
-        },
-      });
-
-      if (result.error) {
-        setCreateError(result.error);
-      } else if (result.data?.payoutId) {
-        setPayoutId(result.data.payoutId);
-      } else {
-        setCreateError("Wompi did not return a payout ID.");
-      }
-    } catch (error) {
-      setCreateError(getRequestError(error));
-    } finally {
-      setCreating(false);
-    }
-  }
-
-  async function handleRefreshStatus() {
-    if (!payoutId) return;
-
-    const requestedPayoutId = payoutId;
-    const requestId = ++statusRequestId.current;
-    setRefreshing(true);
-    setStatusError(null);
-
-    try {
-      const result = await getPayoutStatus({
-        data: { payoutId: requestedPayoutId, rail: "breb" },
-      });
-
-      if (requestId !== statusRequestId.current) return;
-
-      if (result.error) {
-        setStatusError(result.error);
-      } else if (result.data) {
-        setStatus(result.data);
-      } else {
-        setStatusError("Wompi did not return a payout status.");
-      }
-    } catch (error) {
-      if (requestId === statusRequestId.current) {
-        setStatusError(getRequestError(error));
-      }
-    } finally {
-      if (requestId === statusRequestId.current) {
-        setRefreshing(false);
-      }
-    }
-  }
-
-  return (
-    <section aria-labelledby="breb-heading">
-      <div className="section-heading">
-        <div>
-          <h2 id="breb-heading">BRE-B dispersion</h2>
-          <p>Resolve the key before confirming its beneficiary and payout.</p>
-        </div>
-      </div>
-
-      <form className="form-grid" onSubmit={handleResolve}>
-        <label>
-          BRE-B key
-          <input
-            name="key"
-            value={key}
-            disabled={creating}
-            onChange={(event) => {
-              resolveRequestId.current += 1;
-              setKey(event.currentTarget.value);
-              setResolving(false);
-              setConfirmedResolution(null);
-              setResolveError(null);
-            }}
-            placeholder="ecolon@wompi.com"
-            required
-          />
-        </label>
-        <label>
-          Key type <span className="optional">optional</span>
-          <select
-            name="keyType"
-            value={keyType}
-            disabled={creating}
-            onChange={(event) => {
-              resolveRequestId.current += 1;
-              setKeyType(event.currentTarget.value as KeyType | "");
-              setResolving(false);
-              setConfirmedResolution(null);
-              setResolveError(null);
-            }}
-          >
-            <option value="">Auto-detect</option>
-            {KEY_TYPES.map((type) => (
-              <option key={type} value={type}>
-                {type}
-              </option>
-            ))}
-          </select>
-        </label>
-        <div className="form-actions">
-          <button type="submit" disabled={resolving || creating}>
-            {resolving ? "Resolving…" : "Resolve"}
-          </button>
-        </div>
-      </form>
-
-      {resolveError ? (
-        <p className="error" role="alert">
-          {resolveError}
-        </p>
-      ) : null}
-
-      {resolution && confirmedResolution ? (
-        <>
-          <dl className="resolution-details" aria-live="polite">
-            <div>
-              <dt>Masked holder</dt>
-              <dd>{resolution.holderName || "Not provided"}</dd>
-            </div>
-            <div>
-              <dt>Financial entity</dt>
-              <dd>
-                {resolution.financialEntityName || "Not provided"}
-                {resolution.financialEntityCode
-                  ? ` (${resolution.financialEntityCode})`
-                  : ""}
-              </dd>
-            </div>
-            <div>
-              <dt>Resolved key</dt>
-              <dd>{resolution.keyValue || confirmedResolution.key}</dd>
-            </div>
-            <div>
-              <dt>Key type</dt>
-              <dd>
-                {resolution.keyType ||
-                  confirmedResolution.keyType ||
-                  "Auto-detected"}
-              </dd>
-            </div>
-          </dl>
-
-          <form className="form-grid confirm-form" onSubmit={handleCreate}>
-            <h3>Confirm dispersion</h3>
-            <label>
-              Beneficiary name
-              <input name="name" autoComplete="name" required />
-            </label>
-            <label>
-              Beneficiary email
-              <input name="email" type="email" autoComplete="email" required />
-            </label>
-            <label>
-              Amount (COP cents)
-              <input name="amount" type="number" min="1" step="1" required />
-            </label>
-            <AccountSelect accounts={accounts} />
-            <label className="full-width">
-              Reference
-              <input name="reference" placeholder="breb-demo-001" required />
-            </label>
-            {accounts.length === 0 ? (
-              <p className="hint full-width">Load an origin account first.</p>
-            ) : null}
-            <div className="form-actions full-width">
-              <button
-                type="submit"
-                disabled={creating || accounts.length === 0}
-              >
-                {creating ? "Creating…" : "Create BRE-B dispersion"}
-              </button>
-            </div>
-          </form>
-
-          {createError ? (
-            <p className="error" role="alert">
-              {createError}
-            </p>
-          ) : null}
-        </>
-      ) : null}
-
-      {payoutId ? (
-        <PayoutResult
-          payoutId={payoutId}
-          status={status}
-          error={statusError}
-          refreshing={refreshing}
-          onRefresh={handleRefreshStatus}
-        />
-      ) : null}
-    </section>
-  );
-}
-
-function BankDispersion({ accounts }: { accounts: AccountDto[] }) {
-  const [banks, setBanks] = useState<BankDto[]>([]);
-  const [banksError, setBanksError] = useState<string | null>(null);
-  const [banksLoading, setBanksLoading] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [payoutId, setPayoutId] = useState<string | null>(null);
-  const [status, setStatus] = useState<PayoutStatusDto | null>(null);
-  const [statusError, setStatusError] = useState<string | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
-  const statusRequestId = useRef(0);
-
-  async function handleLoadBanks() {
     setBanksLoading(true);
     setBanksError(null);
 
@@ -501,94 +597,194 @@ function BankDispersion({ accounts }: { accounts: AccountDto[] }) {
 
       if (result.error) {
         setBanks([]);
-        setBanksError(result.error);
-      } else if (result.data) {
+        setBanksError(getErrorMessage(result.error));
+      } else if (result.data?.length) {
         setBanks(result.data);
       } else {
-        setBanksError("Wompi did not return any bank data.");
+        setBanksError("Wompi did not return any destination banks.");
       }
     } catch (error) {
       setBanks([]);
-      setBanksError(getRequestError(error));
+      setBanksError(getErrorMessage(error));
     } finally {
       setBanksLoading(false);
     }
   }
 
-  async function handleCreate(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const email = String(formData.get("email")).trim();
+  useEffect(() => {
+    void loadSourceAccounts();
 
-    statusRequestId.current += 1;
-    setCreating(true);
-    setRefreshing(false);
+    try {
+      const stored = window.sessionStorage.getItem(storageKey);
+      if (!stored) return;
+
+      const result = JSON.parse(stored) as PayoutResult;
+      if (
+        result?.payoutId &&
+        (result.rail === "breb" || result.rail === "bank")
+      ) {
+        setPayoutResult(result);
+        void refreshPayoutStatus(result.payoutId, result.rail);
+      }
+    } catch {
+      window.sessionStorage.removeItem(storageKey);
+    }
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (bankReview) bankReviewHeadingRef.current?.focus();
+  }, [bankReview]);
+
+  function selectRail(nextRail: SettlementRail) {
+    setRail(nextRail);
     setCreateError(null);
-    setPayoutId(null);
-    setStatus(null);
+    setCreateWarning(null);
+    setBankReview(false);
+
+    if (nextRail === "bank") {
+      void loadDestinationBanks();
+    }
+  }
+
+  async function handleResolve(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const requestedKey = key.trim();
+    const requestId = ++resolveRequestId.current;
+    setResolving(true);
+    setResolveError(null);
+    setResolution(null);
+    setBrebRecipientConfirmed(false);
+
+    try {
+      const result = await resolveKey({ data: { key: requestedKey } });
+
+      if (requestId !== resolveRequestId.current) return;
+
+      if (result.error) {
+        setResolveError(getErrorMessage(result.error));
+      } else if (result.data) {
+        setResolution(result.data);
+      } else {
+        setResolveError("Wompi did not return a key resolution.");
+      }
+    } catch (error) {
+      if (requestId === resolveRequestId.current) {
+        setResolveError(getErrorMessage(error));
+      }
+    } finally {
+      if (requestId === resolveRequestId.current) {
+        setResolving(false);
+      }
+    }
+  }
+
+  async function submitSettlement(
+    destination:
+      | { rail: "breb"; key: string }
+      | {
+          rail: "bank";
+          bankId: string;
+          accountType: AccountType;
+          accountNumber: string;
+        },
+  ) {
+    setCreating(true);
+    setCreateError(null);
+    setCreateWarning(null);
     setStatusError(null);
 
     try {
       const result = await createDispersion({
         data: {
-          accountId: String(formData.get("accountId")),
-          reference: String(formData.get("reference")).trim(),
-          transaction: {
-            legalIdType: String(
-              formData.get("legalIdType"),
-            ) as (typeof LEGAL_ID_TYPES)[number],
-            legalId: String(formData.get("legalId")).trim(),
-            bankId: String(formData.get("bankId")),
-            accountType: String(
-              formData.get("accountType"),
-            ) as (typeof ACCOUNT_TYPES)[number],
-            accountNumber: String(formData.get("accountNumber")).trim(),
-            name: String(formData.get("name")).trim(),
-            amount: Number(formData.get("amount")),
-            ...(email ? { email } : {}),
-          },
+          accountId,
+          checkoutTransactionId: transaction.id,
+          checkoutReference: transaction.reference,
+          orderProof,
+          destination,
         },
       });
 
       if (result.error) {
-        setCreateError(result.error);
+        setCreateError(getErrorMessage(result.error));
       } else if (result.data?.payoutId) {
-        setPayoutId(result.data.payoutId);
+        const nextResult: PayoutResult = {
+          ...result.data,
+          payoutId: result.data.payoutId,
+          rail: destination.rail,
+        };
+        setPayoutResult(nextResult);
+        window.sessionStorage.setItem(storageKey, JSON.stringify(nextResult));
+
+        if ((result.data.failed ?? 0) > 0) {
+          setCreateWarning(
+            "Wompi accepted the batch, but at least one transfer failed.",
+          );
+        }
+
+        void refreshPayoutStatus(nextResult.payoutId, nextResult.rail);
       } else {
         setCreateError("Wompi did not return a payout ID.");
       }
     } catch (error) {
-      setCreateError(getRequestError(error));
+      setCreateError(getErrorMessage(error));
     } finally {
       setCreating(false);
     }
   }
 
-  async function handleRefreshStatus() {
-    if (!payoutId) return;
+  async function handleBrebSettlement(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (
+      !resolutionConfirmed ||
+      !brebRecipientConfirmed ||
+      !accountId ||
+      sourceAccountBlocked
+    ) {
+      return;
+    }
+    await submitSettlement({ rail: "breb", key: key.trim() });
+  }
 
-    const requestedPayoutId = payoutId;
+  async function handleBankSettlement(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!accountId || sourceAccountBlocked) return;
+
+    if (!bankReview) {
+      setBankReview(true);
+      return;
+    }
+
+    await submitSettlement({
+      rail: "bank",
+      bankId,
+      accountType,
+      accountNumber,
+    });
+  }
+
+  async function refreshPayoutStatus(payoutId: string, payoutRail: PayoutRail) {
     const requestId = ++statusRequestId.current;
     setRefreshing(true);
+    setPayoutStatus(null);
     setStatusError(null);
 
     try {
       const result = await getPayoutStatus({
-        data: { payoutId: requestedPayoutId, rail: "bank" },
+        data: { payoutId, rail: payoutRail },
       });
 
       if (requestId !== statusRequestId.current) return;
 
       if (result.error) {
-        setStatusError(result.error);
+        setStatusError(getErrorMessage(result.error));
       } else if (result.data) {
-        setStatus(result.data);
+        setPayoutStatus(result.data);
       } else {
         setStatusError("Wompi did not return a payout status.");
       }
     } catch (error) {
       if (requestId === statusRequestId.current) {
-        setStatusError(getRequestError(error));
+        setStatusError(getErrorMessage(error));
       }
     } finally {
       if (requestId === statusRequestId.current) {
@@ -597,117 +793,675 @@ function BankDispersion({ accounts }: { accounts: AccountDto[] }) {
     }
   }
 
+  if (payoutResult) {
+    return (
+      <PayoutResultPanel
+        result={payoutResult}
+        status={payoutStatus}
+        warning={createWarning}
+        error={statusError}
+        refreshing={refreshing}
+        onRefresh={() =>
+          refreshPayoutStatus(payoutResult.payoutId, payoutResult.rail)
+        }
+      />
+    );
+  }
+
   return (
-    <section aria-labelledby="bank-heading">
-      <div className="section-heading">
+    <div className="settlement-workspace">
+      <div className="supplier-strip">
         <div>
-          <h2 id="bank-heading">Bank dispersion</h2>
-          <p>Send one sandbox transaction to a Colombian bank account.</p>
+          <span>Supplier</span>
+          <strong>{SUPPLIER_NAME}</strong>
         </div>
-        <button type="button" onClick={handleLoadBanks} disabled={banksLoading}>
-          {banksLoading ? "Loading…" : "Load banks"}
-        </button>
+        <div>
+          <span>Email</span>
+          <strong>{SUPPLIER_EMAIL}</strong>
+        </div>
+        <div>
+          <span>Share</span>
+          <strong>{formatCents(SETTLEMENT_AMOUNT_IN_CENTS)}</strong>
+        </div>
       </div>
 
-      {banksError ? (
-        <p className="error" role="alert">
-          {banksError}
-        </p>
-      ) : null}
-
-      <form className="form-grid" onSubmit={handleCreate}>
-        <label>
-          Legal ID type
-          <select name="legalIdType" defaultValue="CC" required>
-            {LEGAL_ID_TYPES.map((type) => (
-              <option key={type} value={type}>
-                {type}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Legal ID
-          <input name="legalId" required />
-        </label>
-        <label>
-          Destination bank
-          <select name="bankId" required disabled={banks.length === 0}>
-            <option value="">Select a bank</option>
-            {banks.map((bank) => (
-              <option key={bank.id} value={bank.id}>
-                {bank.name || bank.id}
-                {bank.code ? ` (${bank.code})` : ""}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Account type
-          <select name="accountType" defaultValue="AHORROS" required>
-            {ACCOUNT_TYPES.map((type) => (
-              <option key={type} value={type}>
-                {type}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Account number
+      <fieldset className="rail-picker">
+        <legend>Send to</legend>
+        <label className={rail === "breb" ? "is-selected" : ""}>
           <input
-            name="accountNumber"
-            inputMode="numeric"
-            pattern="[0-9]{6,20}"
-            required
+            type="radio"
+            name="rail"
+            value="breb"
+            checked={rail === "breb"}
+            onChange={() => selectRail("breb")}
           />
+          <span>
+            <strong>BRE-B key</strong>
+            <small>Recommended</small>
+          </span>
         </label>
-        <label>
-          Beneficiary name
-          <input name="name" autoComplete="name" required />
+        <label className={rail === "bank" ? "is-selected" : ""}>
+          <input
+            type="radio"
+            name="rail"
+            value="bank"
+            checked={rail === "bank"}
+            onChange={() => selectRail("bank")}
+          />
+          <span>
+            <strong>Bank or wallet</strong>
+            <small>Account details</small>
+          </span>
         </label>
-        <label>
-          Beneficiary email <span className="optional">optional</span>
-          <input name="email" type="email" autoComplete="email" />
-        </label>
-        <label>
-          Amount (COP cents)
-          <input name="amount" type="number" min="1" step="1" required />
-        </label>
-        <AccountSelect accounts={accounts} />
-        <label>
-          Reference
-          <input name="reference" placeholder="bank-demo-001" required />
-        </label>
-        {accounts.length === 0 || banks.length === 0 ? (
-          <p className="hint full-width">
-            Load at least one origin account and the bank catalogue first.
+      </fieldset>
+
+      {rail === "breb" ? (
+        <div className="rail-form">
+          <form className="resolve-row" onSubmit={handleResolve}>
+            <label>
+              BRE-B key
+              <input
+                name="key"
+                value={key}
+                onChange={(event) => {
+                  resolveRequestId.current += 1;
+                  setKey(event.currentTarget.value);
+                  setResolving(false);
+                  setResolution(null);
+                  setResolveError(null);
+                  setBrebRecipientConfirmed(false);
+                }}
+                autoComplete="off"
+                required
+              />
+            </label>
+            <button type="submit" disabled={resolving || !key.trim()}>
+              {resolving ? "Resolving…" : "Resolve key"}
+            </button>
+          </form>
+
+          <p className="field-note">
+            Sandbox example: <code>@elias123</code>
           </p>
-        ) : null}
-        <div className="form-actions full-width">
-          <button
-            type="submit"
-            disabled={creating || accounts.length === 0 || banks.length === 0}
-          >
-            {creating ? "Creating…" : "Create bank dispersion"}
-          </button>
+
+          {resolveError ? (
+            <InlineMessage tone="error">{resolveError}</InlineMessage>
+          ) : null}
+
+          {resolution ? (
+            <form
+              className="confirm-settlement"
+              onSubmit={handleBrebSettlement}
+            >
+              <ResolutionPreview
+                resolution={resolution}
+                fallbackKey={key}
+                confirmed={resolutionConfirmed}
+              />
+              <SourceAccountField
+                accounts={accounts}
+                accountId={accountId}
+                loading={accountsLoading}
+                error={accountsError}
+                onChange={setAccountId}
+                onRetry={loadSourceAccounts}
+              />
+              {!resolutionConfirmed ? (
+                <InlineMessage tone="error">
+                  Wompi did not return enough recipient details to confirm this
+                  key.
+                </InlineMessage>
+              ) : null}
+              {resolutionConfirmed ? (
+                <label className="confirmation-check">
+                  <input
+                    type="checkbox"
+                    checked={brebRecipientConfirmed}
+                    onChange={(event) =>
+                      setBrebRecipientConfirmed(event.currentTarget.checked)
+                    }
+                  />
+                  <span>I confirm this is {SUPPLIER_NAME}'s payout key.</span>
+                </label>
+              ) : null}
+              <button
+                type="submit"
+                disabled={
+                  creating ||
+                  accountsLoading ||
+                  !accountId ||
+                  sourceAccountBlocked ||
+                  !resolutionConfirmed ||
+                  !brebRecipientConfirmed
+                }
+              >
+                {creating ? "Sending…" : "Send COP 40,000"}
+              </button>
+            </form>
+          ) : null}
         </div>
-      </form>
+      ) : (
+        <form
+          className="bank-form"
+          onSubmit={handleBankSettlement}
+          aria-busy={creating || banksLoading}
+        >
+          {bankReview && selectedBank && selectedAccount ? (
+            <div className="bank-review" aria-live="polite">
+              <div>
+                <p className="result-kicker">Review payout</p>
+                <h3 ref={bankReviewHeadingRef} tabIndex={-1}>
+                  Confirm supplier destination
+                </h3>
+              </div>
+              <dl className="review-facts">
+                <div>
+                  <dt>From</dt>
+                  <dd>{accountLabel(selectedAccount)}</dd>
+                </div>
+                <div>
+                  <dt>Available</dt>
+                  <dd>{formatCents(selectedAccount.balanceInCents)}</dd>
+                </div>
+                <div>
+                  <dt>Recipient</dt>
+                  <dd>{SUPPLIER_NAME}</dd>
+                </div>
+                <div>
+                  <dt>Destination</dt>
+                  <dd>
+                    {selectedBank.name ?? selectedBank.code ?? "Destination"} ·
+                    •••• {accountNumber.slice(-4)}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Destination type</dt>
+                  <dd>{accountTypeLabel(accountType)}</dd>
+                </div>
+                <div>
+                  <dt>Amount</dt>
+                  <dd>{formatCents(SETTLEMENT_AMOUNT_IN_CENTS)}</dd>
+                </div>
+                <div>
+                  <dt>Balance after payout</dt>
+                  <dd>
+                    {formatCents(
+                      (selectedAccount.balanceInCents ?? 0) -
+                        SETTLEMENT_AMOUNT_IN_CENTS,
+                    )}
+                  </dd>
+                </div>
+              </dl>
+              <div className="result-actions">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => setBankReview(false)}
+                  disabled={creating}
+                >
+                  Edit details
+                </button>
+                <button type="submit" disabled={creating}>
+                  {creating ? "Sending…" : "Send COP 40,000"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <SourceAccountField
+                accounts={accounts}
+                accountId={accountId}
+                loading={accountsLoading}
+                error={accountsError}
+                onChange={(value) => {
+                  setAccountId(value);
+                  setBankReview(false);
+                }}
+                onRetry={loadSourceAccounts}
+              />
+
+              <div
+                className="supplier-profile"
+                aria-label="Saved supplier profile"
+              >
+                <div>
+                  <span>Saved account holder</span>
+                  <strong>{SUPPLIER_NAME}</strong>
+                </div>
+                <div>
+                  <span>Legal identity</span>
+                  <strong>
+                    {SUPPLIER_PERSON_TYPE === "NATURAL" ? "Person" : "Business"}
+                    {" · "}
+                    {SUPPLIER_LEGAL_ID_TYPE} •••• {SUPPLIER_LEGAL_ID.slice(-4)}
+                  </strong>
+                </div>
+              </div>
+
+              <div className="form-grid">
+                <label>
+                  Bank or digital wallet
+                  <select
+                    name="bankId"
+                    value={bankId}
+                    onChange={(event) => {
+                      const nextBankId = event.currentTarget.value;
+                      const nextBank = banks.find(
+                        (bank) => bank.id === nextBankId,
+                      );
+                      setBankId(nextBankId);
+                      setAccountNumber("");
+                      setAccountType(
+                        nextBank?.isElectronicDeposit
+                          ? "DEPOSITO_ELECTRONICO"
+                          : "AHORROS",
+                      );
+                      setBankReview(false);
+                    }}
+                    disabled={banksLoading || banks.length === 0}
+                    aria-busy={banksLoading}
+                    required
+                  >
+                    <option value="">
+                      {banksLoading
+                        ? "Loading destinations…"
+                        : "Select destination"}
+                    </option>
+                    {banks.map((bank) => (
+                      <option key={bank.id} value={bank.id}>
+                        {bank.name ?? bank.code ?? "Unnamed destination"}
+                        {bank.isElectronicDeposit ? " · Digital wallet" : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {selectedBank?.isElectronicDeposit ? (
+                  <div className="read-only-field">
+                    <span>Destination type</span>
+                    <strong>Digital deposit</strong>
+                  </div>
+                ) : (
+                  <label>
+                    Account type
+                    <select
+                      name="accountType"
+                      value={accountType}
+                      onChange={(event) => {
+                        setAccountType(
+                          event.currentTarget.value as AccountType,
+                        );
+                        setBankReview(false);
+                      }}
+                      required
+                    >
+                      <option value="AHORROS">Savings</option>
+                      <option value="CORRIENTE">Checking</option>
+                    </select>
+                  </label>
+                )}
+
+                <label>
+                  {selectedBank?.isElectronicDeposit
+                    ? "Wallet number"
+                    : "Account number"}
+                  <input
+                    name="accountNumber"
+                    value={accountNumber}
+                    onChange={(event) => {
+                      setAccountNumber(event.currentTarget.value);
+                      setBankReview(false);
+                    }}
+                    inputMode="numeric"
+                    pattern="[0-9]*[1-9][0-9]*"
+                    minLength={6}
+                    maxLength={20}
+                    autoComplete="off"
+                    required
+                  />
+                </label>
+              </div>
+
+              {banksError ? (
+                <InlineMessage tone="error">
+                  {banksError}{" "}
+                  <button
+                    className="inline-button"
+                    type="button"
+                    onClick={loadDestinationBanks}
+                  >
+                    Try again
+                  </button>
+                </InlineMessage>
+              ) : null}
+
+              <button
+                type="submit"
+                disabled={
+                  accountsLoading ||
+                  banksLoading ||
+                  !accountId ||
+                  sourceAccountBlocked ||
+                  !bankId ||
+                  !accountNumber
+                }
+              >
+                Review payout
+              </button>
+            </>
+          )}
+        </form>
+      )}
 
       {createError ? (
-        <p className="error" role="alert">
-          {createError}
-        </p>
+        <InlineMessage tone="error">{createError}</InlineMessage>
+      ) : null}
+    </div>
+  );
+}
+
+function ResolutionPreview({
+  resolution,
+  fallbackKey,
+  confirmed,
+}: {
+  resolution: KeyResolutionDto;
+  fallbackKey: string;
+  confirmed: boolean;
+}) {
+  return (
+    <div
+      className={`resolution-preview${confirmed ? "" : " is-unconfirmed"}`}
+      aria-live="polite"
+    >
+      <div className="resolution-mark" aria-hidden="true">
+        {confirmed ? "✓" : "?"}
+      </div>
+      <div>
+        <p>{confirmed ? "Key found" : "Recipient details incomplete"}</p>
+        <strong>{resolution.holderName || "Masked holder unavailable"}</strong>
+        <span>
+          {resolution.financialEntityName || "Unknown institution"}
+          {resolution.financialEntityCode
+            ? ` · ${resolution.financialEntityCode}`
+            : ""}
+        </span>
+        <code>{resolution.keyValue || fallbackKey}</code>
+      </div>
+    </div>
+  );
+}
+
+function SourceAccountField({
+  accounts,
+  accountId,
+  loading,
+  error,
+  onChange,
+  onRetry,
+}: {
+  accounts: AccountDto[];
+  accountId: string;
+  loading: boolean;
+  error: string | null;
+  onChange: (value: string) => void;
+  onRetry: () => void;
+}) {
+  if (error) {
+    return (
+      <InlineMessage tone="error">
+        {error}{" "}
+        <button className="inline-button" type="button" onClick={onRetry}>
+          Try again
+        </button>
+      </InlineMessage>
+    );
+  }
+
+  const selectedAccount = accounts.find((account) => account.id === accountId);
+  const insufficient = Boolean(
+    selectedAccount?.balanceInCents != null &&
+      selectedAccount.balanceInCents < SETTLEMENT_AMOUNT_IN_CENTS,
+  );
+
+  return (
+    <div className="source-account-group" aria-busy={loading}>
+      <label className="source-account-field">
+        Source account
+        <select
+          value={accountId}
+          onChange={(event) => onChange(event.currentTarget.value)}
+          disabled={loading || accounts.length === 0}
+          required
+        >
+          <option value="">
+            {loading ? "Loading source account…" : "Select source account"}
+          </option>
+          {accounts.map((account) => (
+            <option key={account.id} value={account.id}>
+              {accountLabel(account)} · {formatCents(account.balanceInCents)}
+            </option>
+          ))}
+        </select>
+      </label>
+      {insufficient ? (
+        <InlineMessage tone="error">
+          This account has {formatCents(selectedAccount?.balanceInCents)};{" "}
+          {formatCents(SETTLEMENT_AMOUNT_IN_CENTS)} is required.
+        </InlineMessage>
+      ) : null}
+      {accountId && selectedAccount?.balanceInCents == null ? (
+        <InlineMessage tone="error">
+          Wompi did not report this account balance. Choose an account with a
+          confirmed balance.
+        </InlineMessage>
+      ) : null}
+    </div>
+  );
+}
+
+function accountLabel(account: AccountDto) {
+  const number = account.number;
+  const maskedNumber = number
+    ? `•••• ${number.slice(-4)}`
+    : account.id === "WOMPI_ACCOUNT"
+      ? "Sandbox source"
+      : "Payout account";
+  const institution = account.bankName ?? "Wompi";
+
+  return `${institution} ${maskedNumber}`;
+}
+
+function accountTypeLabel(accountType: AccountType) {
+  if (accountType === "DEPOSITO_ELECTRONICO") return "Digital deposit";
+  return accountType === "CORRIENTE" ? "Checking" : "Savings";
+}
+
+function PayoutResultPanel({
+  result,
+  status,
+  warning,
+  error,
+  refreshing,
+  onRefresh,
+}: {
+  result: PayoutResult;
+  status: PayoutStatusDto | null;
+  warning: string | null;
+  error: string | null;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  const presentation = getPayoutPresentation(result, status);
+
+  return (
+    <div className="result-stack" aria-live="polite">
+      <div className="result-panel">
+        <div className="result-title-row">
+          <div>
+            <p className="result-kicker">Supplier settlement</p>
+            <h3>{presentation.title}</h3>
+          </div>
+          <StatusBadge status={presentation.visibleStatus} />
+        </div>
+
+        <dl className="result-facts">
+          <div>
+            <dt>Amount</dt>
+            <dd>{formatCents(SETTLEMENT_AMOUNT_IN_CENTS)}</dd>
+          </div>
+          <div>
+            <dt>Rail</dt>
+            <dd>{result.rail === "breb" ? "BRE-B" : "Bank or wallet"}</dd>
+          </div>
+        </dl>
+
+        {warning ? (
+          <InlineMessage tone="warning">{warning}</InlineMessage>
+        ) : null}
+        {error ? <InlineMessage tone="error">{error}</InlineMessage> : null}
+        {status?.transactionFailureReason ? (
+          <InlineMessage tone="error">
+            {status.transactionFailureReason}
+          </InlineMessage>
+        ) : null}
+        {status?.transactionLookupError ? (
+          <InlineMessage tone="warning">
+            Transfer details are not available yet.{" "}
+            {status.transactionLookupError}
+          </InlineMessage>
+        ) : null}
+
+        <div className="result-actions">
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+          >
+            {refreshing ? "Refreshing…" : "Refresh status"}
+          </button>
+          <a className="button-link" href="/">
+            Start a new order
+          </a>
+        </div>
+
+        <TechnicalDetails
+          rows={[
+            ["Payout ID", result.payoutId],
+            ["Batch status", status?.status ?? "Submitted"],
+            ["Transfer status", status?.transactionStatus ?? "Pending lookup"],
+            ["Reference", status?.reference ?? "Available after refresh"],
+            [
+              "Created",
+              formatDate(status?.createdAt) ?? "Available after refresh",
+            ],
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className={`status-badge status-${statusTone(status)}`}>
+      {status}
+    </span>
+  );
+}
+
+function TechnicalDetails({ rows }: { rows: Array<[string, string]> }) {
+  return (
+    <details className="technical-details">
+      <summary>Technical details</summary>
+      <dl>
+        {rows.map(([label, value]) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </details>
+  );
+}
+
+function InlineMessage({
+  tone,
+  children,
+}: {
+  tone: "error" | "warning";
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`inline-message message-${tone}`} role="alert">
+      {children}
+    </div>
+  );
+}
+
+function OrderSummary({
+  transaction,
+}: {
+  transaction: CheckoutTransactionDto | null;
+}) {
+  return (
+    <aside className="order-summary" aria-labelledby="order-heading">
+      <div className="order-summary-heading">
+        <div>
+          <p className="eyebrow">Order CO-1042</p>
+          <h2 id="order-heading">{ORDER_NAME}</h2>
+        </div>
+        <span className="quantity">× 1</span>
+      </div>
+
+      <div className="product-art" aria-hidden="true">
+        <span className="package-body" />
+        <span className="package-tape" />
+        <span className="package-label" />
+      </div>
+
+      <dl className="order-lines">
+        <div>
+          <dt>Customer pays</dt>
+          <dd>{formatCents(ORDER_AMOUNT_IN_CENTS)}</dd>
+        </div>
+        <div>
+          <dt>Supplier share</dt>
+          <dd>{formatCents(SETTLEMENT_AMOUNT_IN_CENTS)}</dd>
+        </div>
+        <div className="order-total">
+          <dt>Store remainder</dt>
+          <dd>
+            {formatCents(ORDER_AMOUNT_IN_CENTS - SETTLEMENT_AMOUNT_IN_CENTS)}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="party-list">
+        <div>
+          <span>Customer</span>
+          <strong>{CUSTOMER_NAME}</strong>
+          <small>{CUSTOMER_EMAIL}</small>
+        </div>
+        <div>
+          <span>Supplier</span>
+          <strong>{SUPPLIER_NAME}</strong>
+          <small>{SUPPLIER_EMAIL}</small>
+        </div>
+      </div>
+
+      {transaction ? (
+        <div className="order-state">
+          <StatusBadge status={transaction.status} />
+          <span>Checkout returned</span>
+        </div>
       ) : null}
 
-      {payoutId ? (
-        <PayoutResult
-          payoutId={payoutId}
-          status={status}
-          error={statusError}
-          refreshing={refreshing}
-          onRefresh={handleRefreshStatus}
-        />
-      ) : null}
-    </section>
+      <p className="sandbox-note">
+        Sandbox only. Checkout and Payouts use separate Wompi balances.
+      </p>
+    </aside>
   );
 }

--- a/apps/example/src/routes/index.tsx
+++ b/apps/example/src/routes/index.tsx
@@ -536,15 +536,10 @@ function SettlementWorkspace({
   const bankReviewHeadingRef = useRef<HTMLHeadingElement>(null);
   const storageKey = `wompi-sdk-demo:settlement:${transaction.id}`;
   const selectedAccount = accounts.find((account) => account.id === accountId);
-  const sourceAccountInsufficient = Boolean(
+  const sourceAccountBlocked = Boolean(
     selectedAccount?.balanceInCents != null &&
       selectedAccount.balanceInCents < SETTLEMENT_AMOUNT_IN_CENTS,
   );
-  const sourceAccountBalanceUnavailable = Boolean(
-    selectedAccount && selectedAccount.balanceInCents == null,
-  );
-  const sourceAccountBlocked =
-    sourceAccountInsufficient || sourceAccountBalanceUnavailable;
   const selectedBank = banks.find((bank) => bank.id === bankId);
   const resolutionConfirmed = Boolean(
     resolution?.holderName.trim() &&
@@ -568,7 +563,7 @@ function SettlementWorkspace({
         setAccounts(result.data);
         const fundedAccount = result.data.find(
           (account) =>
-            account.balanceInCents != null &&
+            account.balanceInCents == null ||
             account.balanceInCents >= SETTLEMENT_AMOUNT_IN_CENTS,
         );
         setAccountId(fundedAccount?.id ?? "");
@@ -985,10 +980,12 @@ function SettlementWorkspace({
                 <div>
                   <dt>Balance after payout</dt>
                   <dd>
-                    {formatCents(
-                      (selectedAccount.balanceInCents ?? 0) -
-                        SETTLEMENT_AMOUNT_IN_CENTS,
-                    )}
+                    {selectedAccount.balanceInCents == null
+                      ? "Not reported"
+                      : formatCents(
+                          selectedAccount.balanceInCents -
+                            SETTLEMENT_AMOUNT_IN_CENTS,
+                        )}
                   </dd>
                 </div>
               </dl>
@@ -1251,9 +1248,9 @@ function SourceAccountField({
         </InlineMessage>
       ) : null}
       {accountId && selectedAccount?.balanceInCents == null ? (
-        <InlineMessage tone="error">
-          Wompi did not report this account balance. Choose an account with a
-          confirmed balance.
+        <InlineMessage tone="warning">
+          Wompi did not report this account balance. The payout can still be
+          sent.
         </InlineMessage>
       ) : null}
     </div>

--- a/apps/example/src/server/checkout.test.ts
+++ b/apps/example/src/server/checkout.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createOrderProof,
+  createOrderReference,
+  getCheckoutRedirectUrl,
+  ORDER_AMOUNT_IN_CENTS,
+  toCheckoutTransactionDto,
+  verifyOrderProof,
+} from "./checkout";
+import type { Transaction } from "@pulgueta/wompi/schemas";
+
+describe("checkout helpers", () => {
+  it("uses the fixed order price in cents", () => {
+    expect(ORDER_AMOUNT_IN_CENTS).toBe(4_950_000);
+  });
+
+  it("creates compact, unique order references", () => {
+    const timestamp = 1_721_234_567_890;
+    const first = createOrderReference(
+      timestamp,
+      "123e4567-e89b-12d3-a456-426614174000",
+    );
+    const second = createOrderReference(
+      timestamp,
+      "987e6543-e21b-12d3-a456-426614174000",
+    );
+
+    expect(first).toMatch(/^order-barber-kit-[a-z0-9]+-[a-f0-9]{12}$/);
+    expect(second).not.toBe(first);
+  });
+
+  it("returns to the application origin without carrying request state", () => {
+    expect(
+      getCheckoutRedirectUrl(
+        new URL("https://shop.example.com/orders?id=old#status"),
+        "https://shop.example.com",
+      ),
+    ).toBe("https://shop.example.com/");
+  });
+
+  it("rejects non-web return protocols", () => {
+    expect(() =>
+      getCheckoutRedirectUrl(new URL("file:///tmp/checkout")),
+    ).toThrow("must use HTTP or HTTPS");
+  });
+
+  it("requires a configured origin for a public tunnel", () => {
+    expect(() =>
+      getCheckoutRedirectUrl(new URL("https://shop.example.com/"), ""),
+    ).toThrow("WOMPI_EXAMPLE_ORIGIN");
+  });
+
+  it("signs an order-specific server proof", async () => {
+    const proof = await createOrderProof("order-one", "test_integrity_secret");
+
+    expect(proof).toMatch(/^[a-f0-9]{64}$/);
+    expect(
+      await verifyOrderProof("order-one", proof, "test_integrity_secret"),
+    ).toBe(true);
+    expect(
+      await verifyOrderProof("order-two", proof, "test_integrity_secret"),
+    ).toBe(false);
+    expect(
+      await createOrderProof("order-one", "test_integrity_secret"),
+    ).not.toBe(await createOrderProof("order-two", "test_integrity_secret"));
+  });
+
+  it("verifies the exact launched reference, amount, and currency", () => {
+    const reference = "order-barber-kit-m0abc123-123e4567e89b";
+    const transaction: Transaction = {
+      id: "transaction-1",
+      status: "APPROVED",
+      reference,
+      amount_in_cents: ORDER_AMOUNT_IN_CENTS,
+      currency: "COP",
+    };
+
+    expect(toCheckoutTransactionDto(transaction, reference)).toMatchObject({
+      id: "transaction-1",
+      reference,
+      amountInCents: ORDER_AMOUNT_IN_CENTS,
+      currency: "COP",
+      paymentMethodType: null,
+      statusMessage: null,
+      createdAt: null,
+    });
+    expect(() =>
+      toCheckoutTransactionDto(transaction, `${reference}-different`),
+    ).toThrow("does not belong");
+    expect(() =>
+      toCheckoutTransactionDto(
+        { ...transaction, amount_in_cents: ORDER_AMOUNT_IN_CENTS + 100 },
+        reference,
+      ),
+    ).toThrow("does not belong");
+    expect(() =>
+      toCheckoutTransactionDto(
+        { ...transaction, currency: undefined },
+        reference,
+      ),
+    ).toThrow("does not belong");
+  });
+});

--- a/apps/example/src/server/checkout.ts
+++ b/apps/example/src/server/checkout.ts
@@ -1,0 +1,370 @@
+import { WompiClient } from "@pulgueta/wompi";
+import type { Transaction } from "@pulgueta/wompi/schemas";
+import { buildCheckoutUrl } from "@pulgueta/wompi/server";
+import { createServerFn } from "@tanstack/react-start";
+import { getRequestUrl } from "@tanstack/react-start/server";
+
+export const ORDER_AMOUNT_IN_CENTS = 4_950_000;
+export const ORDER_CURRENCY = "COP" as const;
+
+export type CheckoutErrorDto = {
+  code: "CONFIGURATION" | "INVALID_INPUT" | "WOMPI_REQUEST" | "UNEXPECTED";
+  message: string;
+  statusCode: number | null;
+};
+
+export type CheckoutServerResult<T> =
+  | { error: CheckoutErrorDto; data: null }
+  | { error: null; data: T };
+
+export type CheckoutSessionDto = {
+  checkoutUrl: string;
+  reference: string;
+  orderProof: string;
+  amountInCents: number;
+  currency: typeof ORDER_CURRENCY;
+};
+
+export type CheckoutTransactionDto = {
+  id: string;
+  status: Transaction["status"];
+  reference: string;
+  amountInCents: number | null;
+  currency: string | null;
+  paymentMethodType: string | null;
+  statusMessage: string | null;
+  createdAt: string | null;
+};
+
+export type GetCheckoutTransactionInput = {
+  transactionId: string;
+  expectedReference: string;
+  orderProof: string;
+};
+
+class CheckoutConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CheckoutConfigurationError";
+  }
+}
+
+class CheckoutInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CheckoutInputError";
+  }
+}
+
+function assertLocalDemo() {
+  if (process.env.NODE_ENV !== "development") {
+    throw new CheckoutConfigurationError(
+      "The unauthenticated checkout demo is available only in local development.",
+    );
+  }
+}
+
+function getSandboxPublicKey() {
+  const publicKey = process.env.WOMPI_PUBLIC_KEY?.trim();
+
+  if (!publicKey?.startsWith("pub_test_")) {
+    throw new CheckoutConfigurationError(
+      "Set WOMPI_PUBLIC_KEY to a Wompi sandbox public key (pub_test_...).",
+    );
+  }
+
+  return publicKey;
+}
+
+function getSandboxCheckoutCredentials() {
+  const publicKey = getSandboxPublicKey();
+  const integrityKey = process.env.WOMPI_INTEGRITY_KEY?.trim();
+
+  if (!integrityKey?.startsWith("test_integrity_")) {
+    throw new CheckoutConfigurationError(
+      "Set WOMPI_INTEGRITY_KEY to a Wompi sandbox integrity key (test_integrity_...).",
+    );
+  }
+
+  return { publicKey, integrityKey };
+}
+
+function getStatusCode(error: unknown) {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+
+  return null;
+}
+
+function toCheckoutError(error: unknown): CheckoutErrorDto {
+  if (error instanceof CheckoutConfigurationError) {
+    return { code: "CONFIGURATION", message: error.message, statusCode: null };
+  }
+
+  if (error instanceof CheckoutInputError) {
+    return { code: "INVALID_INPUT", message: error.message, statusCode: null };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: "WOMPI_REQUEST",
+      message: error.message,
+      statusCode: getStatusCode(error),
+    };
+  }
+
+  return {
+    code: "UNEXPECTED",
+    message: "Unexpected checkout error",
+    statusCode: null,
+  };
+}
+
+function parseTransactionId(
+  input: GetCheckoutTransactionInput | null | undefined,
+) {
+  const transactionId =
+    typeof input?.transactionId === "string" ? input.transactionId.trim() : "";
+
+  if (!transactionId || !/^[A-Za-z0-9_-]{1,200}$/.test(transactionId)) {
+    throw new CheckoutInputError("Enter a valid Wompi transaction ID.");
+  }
+
+  return transactionId;
+}
+
+function parseExpectedReference(
+  input: GetCheckoutTransactionInput | null | undefined,
+) {
+  const expectedReference =
+    typeof input?.expectedReference === "string"
+      ? input.expectedReference.trim()
+      : "";
+
+  if (!/^order-barber-kit-[a-z0-9]+-[a-f0-9]{12}$/.test(expectedReference)) {
+    throw new CheckoutInputError(
+      "This browser no longer has the launched order reference. Start another checkout.",
+    );
+  }
+
+  return expectedReference;
+}
+
+function parseOrderProof(
+  input: GetCheckoutTransactionInput | null | undefined,
+) {
+  const orderProof =
+    typeof input?.orderProof === "string" ? input.orderProof.trim() : "";
+
+  if (!/^[a-f0-9]{64}$/.test(orderProof)) {
+    throw new CheckoutInputError(
+      "This browser no longer has a valid checkout proof. Start another checkout.",
+    );
+  }
+
+  return orderProof;
+}
+
+export function createOrderReference(
+  timestamp = Date.now(),
+  entropy = crypto.randomUUID(),
+) {
+  const compactEntropy = entropy.replaceAll("-", "").slice(0, 12);
+  return `order-barber-kit-${timestamp.toString(36)}-${compactEntropy}`;
+}
+
+function getOrderProofPayload(reference: string) {
+  return new TextEncoder().encode(
+    `${reference}|${ORDER_AMOUNT_IN_CENTS}|${ORDER_CURRENCY}`,
+  );
+}
+
+async function getOrderProofKey(integrityKey: string) {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(integrityKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function createOrderProof(
+  reference: string,
+  integrityKey: string,
+) {
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    await getOrderProofKey(integrityKey),
+    getOrderProofPayload(reference),
+  );
+  return Array.from(new Uint8Array(signature), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export async function verifyOrderProof(
+  reference: string,
+  orderProof: string,
+  integrityKey: string,
+) {
+  const received = Uint8Array.from(orderProof.match(/.{2}/g) ?? [], (byte) =>
+    Number.parseInt(byte, 16),
+  );
+  return crypto.subtle.verify(
+    "HMAC",
+    await getOrderProofKey(integrityKey),
+    received,
+    getOrderProofPayload(reference),
+  );
+}
+
+export function getCheckoutRedirectUrl(
+  requestUrl: URL,
+  configuredOrigin?: string,
+) {
+  const redirectBase = configuredOrigin
+    ? new URL(configuredOrigin)
+    : requestUrl;
+  if (redirectBase.protocol !== "http:" && redirectBase.protocol !== "https:") {
+    throw new CheckoutConfigurationError(
+      "The checkout return URL must use HTTP or HTTPS.",
+    );
+  }
+
+  const hostname = redirectBase.hostname;
+  if (
+    !configuredOrigin &&
+    hostname !== "localhost" &&
+    hostname !== "127.0.0.1" &&
+    !hostname.endsWith(".localhost")
+  ) {
+    throw new CheckoutConfigurationError(
+      "Set WOMPI_EXAMPLE_ORIGIN to the public HTTPS origin used by this demo.",
+    );
+  }
+
+  return new URL("/", redirectBase.origin).toString();
+}
+
+export function toCheckoutTransactionDto(
+  transaction: Transaction,
+  expectedReference: string,
+): CheckoutTransactionDto {
+  if (
+    transaction.reference !== expectedReference ||
+    transaction.amount_in_cents !== ORDER_AMOUNT_IN_CENTS ||
+    transaction.currency !== ORDER_CURRENCY
+  ) {
+    throw new CheckoutInputError(
+      "That transaction does not belong to this sandbox order.",
+    );
+  }
+
+  return {
+    id: transaction.id,
+    status: transaction.status,
+    reference: transaction.reference,
+    amountInCents: transaction.amount_in_cents ?? null,
+    currency: transaction.currency ?? null,
+    paymentMethodType: transaction.payment_method_type ?? null,
+    statusMessage: transaction.status_message ?? null,
+    createdAt: transaction.created_at ?? null,
+  };
+}
+
+export async function verifyCheckoutTransaction(
+  input: GetCheckoutTransactionInput,
+  requireApproval = false,
+) {
+  assertLocalDemo();
+  const transactionId = parseTransactionId(input);
+  const expectedReference = parseExpectedReference(input);
+  const orderProof = parseOrderProof(input);
+  const { publicKey, integrityKey } = getSandboxCheckoutCredentials();
+
+  if (!(await verifyOrderProof(expectedReference, orderProof, integrityKey))) {
+    throw new CheckoutInputError(
+      "The checkout proof does not match this sandbox order.",
+    );
+  }
+
+  const client = new WompiClient({ publicKey, sandbox: true });
+  const [error, transaction] =
+    await client.transactions.getTransaction(transactionId);
+
+  if (error) throw error;
+
+  const verified = toCheckoutTransactionDto(transaction, expectedReference);
+  if (requireApproval && verified.status !== "APPROVED") {
+    throw new CheckoutInputError(
+      "The customer checkout must be approved before settling the supplier.",
+    );
+  }
+
+  return verified;
+}
+
+export const createCheckoutSession = createServerFn({ method: "POST" }).handler(
+  async (): Promise<CheckoutServerResult<CheckoutSessionDto>> => {
+    try {
+      assertLocalDemo();
+      const { publicKey, integrityKey } = getSandboxCheckoutCredentials();
+      const reference = createOrderReference();
+      const orderProof = await createOrderProof(reference, integrityKey);
+      const redirectUrl = getCheckoutRedirectUrl(
+        getRequestUrl(),
+        process.env.WOMPI_EXAMPLE_ORIGIN,
+      );
+      const checkoutUrl = await buildCheckoutUrl({
+        publicKey,
+        integrityKey,
+        reference,
+        amountInCents: ORDER_AMOUNT_IN_CENTS,
+        currency: ORDER_CURRENCY,
+        redirectUrl,
+        collectShipping: false,
+        customerData: {
+          email: "laura@example.com",
+          fullName: "Laura Mendoza",
+          phoneNumber: "3001234567",
+          phoneNumberPrefix: "+57",
+        },
+      });
+
+      return {
+        error: null,
+        data: {
+          checkoutUrl,
+          reference,
+          orderProof,
+          amountInCents: ORDER_AMOUNT_IN_CENTS,
+          currency: ORDER_CURRENCY,
+        },
+      };
+    } catch (error) {
+      return { error: toCheckoutError(error), data: null };
+    }
+  },
+);
+
+export const getCheckoutTransaction = createServerFn({ method: "POST" })
+  .validator((data: GetCheckoutTransactionInput) => data)
+  .handler(
+    async ({ data }): Promise<CheckoutServerResult<CheckoutTransactionDto>> => {
+      try {
+        return {
+          error: null,
+          data: await verifyCheckoutTransaction(data),
+        };
+      } catch (error) {
+        return { error: toCheckoutError(error), data: null };
+      }
+    },
+  );

--- a/apps/example/src/server/idempotency.test.ts
+++ b/apps/example/src/server/idempotency.test.ts
@@ -4,7 +4,7 @@ import { createDispersionIdempotencyKey } from "./idempotency";
 const bankOperation = {
   accountId: "account-1",
   reference: "demo-001",
-  paymentType: "OTHER" as const,
+  paymentType: "PROVIDERS" as const,
   transaction: {
     legalIdType: "CC" as const,
     legalId: "1234567890",

--- a/apps/example/src/server/payouts.test.ts
+++ b/apps/example/src/server/payouts.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDispersionOperation,
+  createSettlementReference,
+  SETTLEMENT_AMOUNT_IN_CENTS,
+  SUPPLIER_EMAIL,
+  SUPPLIER_NAME,
+} from "./payouts";
+
+const baseInput = {
+  accountId: "WOMPI_ACCOUNT",
+  checkoutTransactionId: "transaction-001",
+  checkoutReference: "order-barber-kit-001",
+  orderProof: "proof-001",
+};
+
+const settlementReference = createSettlementReference(
+  baseInput.checkoutTransactionId,
+);
+
+describe("buildDispersionOperation", () => {
+  it("builds the complete supplier bank transfer", () => {
+    expect(
+      buildDispersionOperation({
+        ...baseInput,
+        destination: {
+          rail: "bank",
+          bankId: "bancolombia",
+          accountType: "AHORROS",
+          accountNumber: " 12345678 ",
+        },
+      }),
+    ).toEqual({
+      accountId: "WOMPI_ACCOUNT",
+      reference: settlementReference,
+      paymentType: "PROVIDERS",
+      transaction: {
+        personType: "NATURAL",
+        legalIdType: "CC",
+        legalId: "1000000000",
+        bankId: "bancolombia",
+        accountType: "AHORROS",
+        accountNumber: "12345678",
+        name: SUPPLIER_NAME,
+        email: SUPPLIER_EMAIL,
+        amount: SETTLEMENT_AMOUNT_IN_CENTS,
+        reference: settlementReference,
+        description: "Supplier share for order-barber-kit-001",
+      },
+    });
+  });
+
+  it("builds a BRE-B transfer without bank-only fields", () => {
+    const operation = buildDispersionOperation({
+      ...baseInput,
+      destination: { rail: "breb", key: " @elias123 " },
+    });
+
+    expect(operation).toEqual({
+      accountId: "WOMPI_ACCOUNT",
+      reference: settlementReference,
+      paymentType: "PROVIDERS",
+      transaction: {
+        key: "@elias123",
+        name: SUPPLIER_NAME,
+        email: SUPPLIER_EMAIL,
+        amount: SETTLEMENT_AMOUNT_IN_CENTS,
+        reference: settlementReference,
+        description: "Supplier share for order-barber-kit-001",
+      },
+    });
+    expect(operation.transaction).not.toHaveProperty("bankId");
+    expect(operation.transaction).not.toHaveProperty("personType");
+  });
+
+  it("derives the same settlement reference for every retry of one checkout", () => {
+    expect(createSettlementReference("transaction-001")).toBe(
+      createSettlementReference("transaction-001"),
+    );
+    expect(createSettlementReference("transaction-001")).not.toBe(
+      createSettlementReference("transaction-002"),
+    );
+  });
+});

--- a/apps/example/src/server/payouts.test.ts
+++ b/apps/example/src/server/payouts.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildDispersionOperation,
+  type CreateResultDto,
   createSettlementReference,
+  getPayoutsClient,
+  type PayoutErrorDto,
+  runSettlementAttempt,
   SETTLEMENT_AMOUNT_IN_CENTS,
+  type ServerResult,
   SUPPLIER_EMAIL,
   SUPPLIER_NAME,
 } from "./payouts";
@@ -81,5 +86,94 @@ describe("buildDispersionOperation", () => {
     expect(createSettlementReference("transaction-001")).not.toBe(
       createSettlementReference("transaction-002"),
     );
+  });
+});
+
+describe("getPayoutsClient", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("throws a clear error naming both missing credentials", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("WOMPI_PAYOUTS_API_KEY", "");
+    vi.stubEnv("WOMPI_PAYOUTS_USER_PRINCIPAL_ID", "");
+
+    expect(() => getPayoutsClient()).toThrowError(
+      "Wompi payouts credentials missing. Set WOMPI_PAYOUTS_API_KEY and WOMPI_PAYOUTS_USER_PRINCIPAL_ID in the example app environment.",
+    );
+  });
+
+  it("names only the credential that is missing", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("WOMPI_PAYOUTS_API_KEY", "some-key");
+    vi.stubEnv("WOMPI_PAYOUTS_USER_PRINCIPAL_ID", "");
+
+    expect(() => getPayoutsClient()).toThrowError(
+      "Wompi payouts credentials missing. Set WOMPI_PAYOUTS_USER_PRINCIPAL_ID in the example app environment.",
+    );
+  });
+});
+
+describe("runSettlementAttempt", () => {
+  const failure = (
+    statusCode: number | null,
+  ): ServerResult<CreateResultDto> => ({
+    error: { code: "WOMPI_REQUEST", message: "failed", statusCode },
+    data: null,
+  });
+  const success: ServerResult<CreateResultDto> = {
+    error: null,
+    data: { payoutId: "payout-1", transactions: 1, success: 1, failed: 0 },
+  };
+
+  it.each<[string, PayoutErrorDto["statusCode"]]>([
+    ["a network error", 0],
+    ["an unknown error", null],
+    ["a 5xx server error", 502],
+  ])(
+    "keeps the attempt record after %s so a retry reuses the same idempotency key",
+    async (_label, statusCode) => {
+      const attempts = new Map<
+        string,
+        Promise<ServerResult<CreateResultDto>>
+      >();
+      const run = vi.fn().mockResolvedValue(failure(statusCode));
+
+      const first = await runSettlementAttempt("checkout-1", run, attempts);
+      expect(first.error?.statusCode).toBe(statusCode);
+      expect(attempts.has("checkout-1")).toBe(true);
+
+      const second = await runSettlementAttempt("checkout-1", run, attempts);
+      expect(second).toBe(first);
+      expect(run).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("clears the attempt record after a definitive rejection so a fresh attempt can run", async () => {
+    const attempts = new Map<string, Promise<ServerResult<CreateResultDto>>>();
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce(failure(422))
+      .mockResolvedValueOnce(success);
+
+    const first = await runSettlementAttempt("checkout-1", run, attempts);
+    expect(first.error?.statusCode).toBe(422);
+    expect(attempts.has("checkout-1")).toBe(false);
+
+    const second = await runSettlementAttempt("checkout-1", run, attempts);
+    expect(second).toBe(success);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the attempt record after a success to block duplicate settlements", async () => {
+    const attempts = new Map<string, Promise<ServerResult<CreateResultDto>>>();
+    const run = vi.fn().mockResolvedValue(success);
+
+    await runSettlementAttempt("checkout-1", run, attempts);
+    await runSettlementAttempt("checkout-1", run, attempts);
+
+    expect(attempts.has("checkout-1")).toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example/src/server/payouts.ts
+++ b/apps/example/src/server/payouts.ts
@@ -117,16 +117,28 @@ const FRIENDLY_PAYOUT_ERRORS: Record<string, string> = {
   EXC_037: "BRE-B resolution timed out. Try again.",
 };
 
-function getPayoutsClient() {
+export function getPayoutsClient() {
   if (process.env.NODE_ENV !== "development") {
     throw new Error(
       "The unauthenticated payouts demo is available only in local development",
     );
   }
 
+  const apiKey = process.env.WOMPI_PAYOUTS_API_KEY;
+  const userPrincipalId = process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID;
+  if (!apiKey || !userPrincipalId) {
+    const missing = [
+      apiKey ? null : "WOMPI_PAYOUTS_API_KEY",
+      userPrincipalId ? null : "WOMPI_PAYOUTS_USER_PRINCIPAL_ID",
+    ].filter(Boolean);
+    throw new Error(
+      `Wompi payouts credentials missing. Set ${missing.join(" and ")} in the example app environment.`,
+    );
+  }
+
   payoutsClient ??= new WompiPayoutsClient({
-    apiKey: process.env.WOMPI_PAYOUTS_API_KEY ?? "",
-    userPrincipalId: process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID ?? "",
+    apiKey,
+    userPrincipalId,
     sandbox: true,
   });
 
@@ -272,6 +284,40 @@ export const resolveKey = createServerFn({ method: "POST" })
       ),
   );
 
+// A payout is only provably rejected when Wompi answered with a 4xx status.
+// Network errors (statusCode 0), timeouts, 5xx and unparseable responses are
+// ambiguous: Wompi may still have accepted the payout, so we must not treat them
+// as a clean rejection.
+function isAmbiguousPayoutFailure(error: PayoutErrorDto) {
+  return (
+    error.statusCode === null ||
+    error.statusCode < 400 ||
+    error.statusCode >= 500
+  );
+}
+
+// Dedupes concurrent settlements per checkout and, on failure, only forgets the
+// attempt when Wompi provably rejected it. On ambiguous failures the record is
+// kept so the deterministic idempotency key is reused on retry (letting Wompi
+// dedupe within its window) and the payout can be recovered via getPayoutStatus,
+// never risking a second supplier payout.
+export async function runSettlementAttempt(
+  checkoutId: string,
+  run: () => Promise<ServerResult<CreateResultDto>>,
+  attempts = settlementAttempts,
+): Promise<ServerResult<CreateResultDto>> {
+  const existingAttempt = attempts.get(checkoutId);
+  if (existingAttempt) return existingAttempt;
+
+  const attempt = run();
+  attempts.set(checkoutId, attempt);
+  const result = await attempt;
+  if (result.error && !isAmbiguousPayoutFailure(result.error)) {
+    attempts.delete(checkoutId);
+  }
+  return result;
+}
+
 export const createDispersion = createServerFn({ method: "POST" })
   .validator((data: CreateDispersionInput) => data)
   .handler(async ({ data }): Promise<ServerResult<CreateResultDto>> => {
@@ -284,35 +330,31 @@ export const createDispersion = createServerFn({ method: "POST" })
         },
         true,
       );
-      const existingAttempt = settlementAttempts.get(verifiedCheckout.id);
-      if (existingAttempt) return existingAttempt;
 
       const operation = buildDispersionOperation(data);
       const idempotencyKey = createDispersionIdempotencyKey({
         checkoutTransactionId: verifiedCheckout.id,
       });
-      const attempt = runPayoutRequest(
-        (client) =>
-          client.createPayout(
-            {
-              reference: operation.reference,
-              accountId: operation.accountId,
-              paymentType: operation.paymentType,
-              transactions: [operation.transaction],
-            },
-            { idempotencyKey },
-          ),
-        ({ payoutId, transactions, success, failed }) => ({
-          payoutId,
-          transactions,
-          success,
-          failed,
-        }),
+      return runSettlementAttempt(verifiedCheckout.id, () =>
+        runPayoutRequest(
+          (client) =>
+            client.createPayout(
+              {
+                reference: operation.reference,
+                accountId: operation.accountId,
+                paymentType: operation.paymentType,
+                transactions: [operation.transaction],
+              },
+              { idempotencyKey },
+            ),
+          ({ payoutId, transactions, success, failed }) => ({
+            payoutId,
+            transactions,
+            success,
+            failed,
+          }),
+        ),
       );
-      settlementAttempts.set(verifiedCheckout.id, attempt);
-      const result = await attempt;
-      if (result.error) settlementAttempts.delete(verifiedCheckout.id);
-      return result;
     } catch (error) {
       return { error: toPayoutError(error), data: null };
     }

--- a/apps/example/src/server/payouts.ts
+++ b/apps/example/src/server/payouts.ts
@@ -1,6 +1,5 @@
-import { env } from "node:process";
-
 import { WompiPayoutsClient } from "@pulgueta/wompi";
+import { WompiPayoutApiError } from "@pulgueta/wompi/schemas";
 import type {
   BrebKeyType,
   CreatePayoutTransaction,
@@ -9,21 +8,39 @@ import type {
 import { createServerFn } from "@tanstack/react-start";
 
 import { createDispersionIdempotencyKey } from "./idempotency";
+import { verifyCheckoutTransaction } from "./checkout";
 
-type ServerResult<T> = { error: string; data: null } | { error: null; data: T };
+export type PayoutErrorDto = {
+  code: string;
+  message: string;
+  statusCode: number | null;
+};
+
+export type ServerResult<T> =
+  | { error: PayoutErrorDto; data: null }
+  | { error: null; data: T };
+
+export const SETTLEMENT_AMOUNT_IN_CENTS = 4_000_000;
+export const SUPPLIER_NAME = "Elias Cano";
+export const SUPPLIER_EMAIL = "seller@example.com";
+export const SUPPLIER_PERSON_TYPE = "NATURAL" as const;
+export const SUPPLIER_LEGAL_ID_TYPE = "CC" as const;
+export const SUPPLIER_LEGAL_ID = "1000000000";
 
 export type AccountDto = {
   id: string;
   number?: string;
-  balanceInCents?: number;
+  balanceInCents?: number | null;
   status?: string;
   accountType?: string;
+  bankName?: string;
 };
 
 export type BankDto = {
   id: string;
   name?: string;
   code?: string;
+  isElectronicDeposit?: boolean;
 };
 
 export type KeyResolutionDto = {
@@ -46,6 +63,9 @@ export type PayoutStatusDto = {
   status: string;
   reference?: string;
   createdAt?: string;
+  transactionStatus?: string;
+  transactionFailureReason?: string;
+  transactionLookupError?: string;
 };
 
 export type ResolveKeyInput = {
@@ -55,28 +75,136 @@ export type ResolveKeyInput = {
 
 export type CreateDispersionInput = {
   accountId: string;
-  reference: string;
-  transaction: CreatePayoutTransaction;
+  checkoutTransactionId: string;
+  checkoutReference: string;
+  orderProof: string;
+  destination:
+    | { rail: "breb"; key: string }
+    | {
+        rail: "bank";
+        bankId: string;
+        accountType: "AHORROS" | "CORRIENTE" | "DEPOSITO_ELECTRONICO";
+        accountNumber: string;
+      };
 };
 
 export type PayoutRail = "bank" | "breb";
 
+export type DispersionOperation = {
+  accountId: string;
+  reference: string;
+  paymentType: "PROVIDERS";
+  transaction: CreatePayoutTransaction;
+};
+
 let payoutsClient: WompiPayoutsClient | null = null;
+const settlementAttempts = new Map<
+  string,
+  Promise<ServerResult<CreateResultDto>>
+>();
+
+const FRIENDLY_PAYOUT_ERRORS: Record<string, string> = {
+  EXC_008: "The source account does not have enough available balance.",
+  EXC_017: "This payout would exceed the account's daily limit.",
+  EXC_022:
+    "This bank payout was already submitted. Keep the original payout ID.",
+  EXC_032:
+    "This BRE-B payout was already submitted. Keep the original payout ID.",
+  EXC_033: "The BRE-B key format is not valid.",
+  EXC_034: "We could not find an active BRE-B key. Try a listed sandbox key.",
+  EXC_035: "That BRE-B key is inactive.",
+  EXC_036: "BRE-B resolution is temporarily unavailable.",
+  EXC_037: "BRE-B resolution timed out. Try again.",
+};
 
 function getPayoutsClient() {
-  if (env.NODE_ENV !== "development") {
+  if (process.env.NODE_ENV !== "development") {
     throw new Error(
       "The unauthenticated payouts demo is available only in local development",
     );
   }
 
   payoutsClient ??= new WompiPayoutsClient({
-    apiKey: env.WOMPI_PAYOUTS_API_KEY ?? "",
-    userPrincipalId: env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID ?? "",
+    apiKey: process.env.WOMPI_PAYOUTS_API_KEY ?? "",
+    userPrincipalId: process.env.WOMPI_PAYOUTS_USER_PRINCIPAL_ID ?? "",
     sandbox: true,
   });
 
   return payoutsClient;
+}
+
+export function buildDispersionOperation(
+  data: CreateDispersionInput,
+): DispersionOperation {
+  const reference = createSettlementReference(data.checkoutTransactionId);
+  const transactionBase = {
+    name: SUPPLIER_NAME,
+    email: SUPPLIER_EMAIL,
+    amount: SETTLEMENT_AMOUNT_IN_CENTS,
+    reference,
+    description: `Supplier share for ${data.checkoutReference}`,
+  };
+  const transaction: CreatePayoutTransaction =
+    data.destination.rail === "breb"
+      ? { ...transactionBase, key: data.destination.key.trim() }
+      : {
+          ...transactionBase,
+          personType: SUPPLIER_PERSON_TYPE,
+          legalIdType: SUPPLIER_LEGAL_ID_TYPE,
+          legalId: SUPPLIER_LEGAL_ID,
+          bankId: data.destination.bankId,
+          accountType: data.destination.accountType,
+          accountNumber: data.destination.accountNumber.trim(),
+        };
+
+  return {
+    accountId: data.accountId,
+    reference,
+    paymentType: "PROVIDERS",
+    transaction,
+  };
+}
+
+export function createSettlementReference(checkoutTransactionId: string) {
+  const compactId = checkoutTransactionId.replace(/[^A-Za-z0-9]/g, "");
+  return `settlement-${compactId.slice(0, 24)}`;
+}
+
+function getStatusCode(error: unknown) {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    typeof error.statusCode === "number"
+  ) {
+    return error.statusCode;
+  }
+
+  return null;
+}
+
+function toPayoutError(error: unknown): PayoutErrorDto {
+  if (error instanceof WompiPayoutApiError) {
+    return {
+      code: error.code,
+      message: FRIENDLY_PAYOUT_ERRORS[error.code] ?? error.message,
+      statusCode: error.statusCode,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: "WOMPI_REQUEST",
+      message: error.message,
+      statusCode: getStatusCode(error),
+    };
+  }
+
+  return {
+    code: "UNEXPECTED",
+    message: "The payout request could not be completed.",
+    statusCode: null,
+  };
 }
 
 async function runPayoutRequest<T, TDto>(
@@ -87,31 +215,30 @@ async function runPayoutRequest<T, TDto>(
     const [error, data] = await request(getPayoutsClient());
 
     if (error) {
-      return { error: error.message, data: null };
+      return { error: toPayoutError(error), data: null };
     }
 
     return { error: null, data: mapData(data) };
   } catch (error) {
-    return {
-      error:
-        error instanceof Error ? error.message : "Unexpected payouts error",
-      data: null,
-    };
+    return { error: toPayoutError(error), data: null };
   }
 }
 
 export const listAccounts = createServerFn({ method: "POST" }).handler(
   async (): Promise<ServerResult<AccountDto[]>> =>
     runPayoutRequest(
-      (client) => client.listAccounts(),
+      (client) => client.listAccounts({ status: "ACTIVE" }),
       (accounts) =>
-        accounts.map(({ id, number, balanceInCents, status, accountType }) => ({
-          id,
-          number,
-          balanceInCents,
-          status,
-          accountType,
-        })),
+        accounts.map(
+          ({ id, number, balanceInCents, status, accountType, bank }) => ({
+            id,
+            number,
+            balanceInCents,
+            status,
+            accountType,
+            bankName: bank?.name,
+          }),
+        ),
     ),
 );
 
@@ -119,7 +246,13 @@ export const listBanks = createServerFn({ method: "POST" }).handler(
   async (): Promise<ServerResult<BankDto[]>> =>
     runPayoutRequest(
       (client) => client.listBanks(),
-      (banks) => banks.map(({ id, name, code }) => ({ id, name, code })),
+      (banks) =>
+        banks.map(({ id, name, code, isElectronicDeposit }) => ({
+          id,
+          name,
+          code,
+          isElectronicDeposit,
+        })),
     ),
 );
 
@@ -142,48 +275,90 @@ export const resolveKey = createServerFn({ method: "POST" })
 export const createDispersion = createServerFn({ method: "POST" })
   .validator((data: CreateDispersionInput) => data)
   .handler(async ({ data }): Promise<ServerResult<CreateResultDto>> => {
-    const operation = {
-      accountId: data.accountId,
-      reference: data.reference,
-      paymentType: "OTHER" as const,
-      transaction: data.transaction,
-    };
-    const idempotencyKey = createDispersionIdempotencyKey(operation);
+    try {
+      const verifiedCheckout = await verifyCheckoutTransaction(
+        {
+          transactionId: data.checkoutTransactionId,
+          expectedReference: data.checkoutReference,
+          orderProof: data.orderProof,
+        },
+        true,
+      );
+      const existingAttempt = settlementAttempts.get(verifiedCheckout.id);
+      if (existingAttempt) return existingAttempt;
 
-    return runPayoutRequest(
-      (client) =>
-        client.createPayout(
-          {
-            reference: operation.reference,
-            accountId: operation.accountId,
-            paymentType: operation.paymentType,
-            transactions: [operation.transaction],
-          },
-          { idempotencyKey },
-        ),
-      ({ payoutId, transactions, success, failed }) => ({
-        payoutId,
-        transactions,
-        success,
-        failed,
-      }),
-    );
+      const operation = buildDispersionOperation(data);
+      const idempotencyKey = createDispersionIdempotencyKey({
+        checkoutTransactionId: verifiedCheckout.id,
+      });
+      const attempt = runPayoutRequest(
+        (client) =>
+          client.createPayout(
+            {
+              reference: operation.reference,
+              accountId: operation.accountId,
+              paymentType: operation.paymentType,
+              transactions: [operation.transaction],
+            },
+            { idempotencyKey },
+          ),
+        ({ payoutId, transactions, success, failed }) => ({
+          payoutId,
+          transactions,
+          success,
+          failed,
+        }),
+      );
+      settlementAttempts.set(verifiedCheckout.id, attempt);
+      const result = await attempt;
+      if (result.error) settlementAttempts.delete(verifiedCheckout.id);
+      return result;
+    } catch (error) {
+      return { error: toPayoutError(error), data: null };
+    }
   });
 
 export const getPayoutStatus = createServerFn({ method: "POST" })
   .validator((data: { payoutId: string; rail: PayoutRail }) => data)
-  .handler(
-    async ({ data }): Promise<ServerResult<PayoutStatusDto>> =>
-      runPayoutRequest(
-        (client) =>
-          client.getPayout(data.payoutId, {
-            apiVersion: data.rail === "breb" ? "v2" : "v1",
-          }),
-        ({ id, status, reference, createdAt }) => ({
-          id,
-          status,
-          reference,
-          createdAt,
-        }),
-      ),
-  );
+  .handler(async ({ data }): Promise<ServerResult<PayoutStatusDto>> => {
+    try {
+      const client = getPayoutsClient();
+      const apiVersion = data.rail === "breb" ? "v2" : "v1";
+      const [payoutError, payout] = await client.getPayout(data.payoutId, {
+        apiVersion,
+      });
+
+      if (payoutError) {
+        return { error: toPayoutError(payoutError), data: null };
+      }
+
+      const [transactionError, page] = await client.listPayoutTransactions(
+        data.payoutId,
+        {},
+        { apiVersion },
+      );
+      const transaction = page?.records[0];
+      const failureReason = transaction?.failureReason;
+      const transactionFailureReason =
+        typeof failureReason === "string"
+          ? failureReason
+          : (failureReason?.message ?? failureReason?.description);
+
+      return {
+        error: null,
+        data: {
+          id: payout.id,
+          status: payout.status,
+          reference: payout.reference,
+          createdAt: payout.createdAt,
+          transactionStatus: transaction?.status,
+          transactionFailureReason,
+          transactionLookupError: transactionError
+            ? toPayoutError(transactionError).message
+            : undefined,
+        },
+      };
+    } catch (error) {
+      return { error: toPayoutError(error), data: null };
+    }
+  });

--- a/apps/example/src/styles.css
+++ b/apps/example/src/styles.css
@@ -3,15 +3,39 @@
   background: #f3f6f4;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
   line-height: 1.5;
+  text-rendering: optimizeLegibility;
+  --canvas: #f3f6f4;
+  --surface: #ffffff;
+  --ink: #17211b;
+  --muted: #526057;
+  --soft-muted: #5f6b63;
+  --divider: #d5ded8;
+  --divider-strong: #b8c5bd;
+  --green: #126b42;
+  --green-deep: #0e5535;
+  --green-soft: #eaf5ef;
+  --danger: #a93226;
+  --danger-soft: #fff1f0;
+  --warning: #775a12;
+  --warning-soft: #fff8df;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  min-width: 20rem;
+  background: var(--canvas);
+}
+
 body {
+  min-height: 100vh;
   margin: 0;
+  color: var(--ink);
+  background: var(--canvas);
 }
 
 button,
@@ -20,19 +44,29 @@ select {
   font: inherit;
 }
 
-button {
+button,
+.button-link {
+  display: inline-flex;
+  min-height: 2.75rem;
   width: fit-content;
-  border: 0;
-  border-radius: 0.5rem;
-  padding: 0.65rem 0.9rem;
-  color: #fff;
-  background: #126b42;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--green);
+  border-radius: 0.375rem;
+  padding: 0.625rem 1rem;
+  color: #ffffff;
+  background: var(--green);
   cursor: pointer;
-  font-weight: 650;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.25;
+  text-decoration: none;
 }
 
-button:hover:not(:disabled) {
-  background: #0e5535;
+button:hover:not(:disabled),
+.button-link:hover {
+  border-color: var(--green-deep);
+  background: var(--green-deep);
 }
 
 button:disabled {
@@ -40,213 +74,998 @@ button:disabled {
   opacity: 0.55;
 }
 
-main {
-  width: min(56rem, calc(100% - 2rem));
-  margin: 3rem auto;
+a {
+  color: inherit;
 }
 
-.page-header {
-  margin-bottom: 2rem;
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.875em;
+  overflow-wrap: anywhere;
 }
 
-.page-header h1 {
-  margin: 0.15rem 0 0.5rem;
-  font-size: clamp(2rem, 6vw, 3.25rem);
-  letter-spacing: -0.04em;
+.topbar {
+  display: flex;
+  min-height: 3.75rem;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--divider);
+  padding: 0 2rem;
+  background: rgb(255 255 255 / 88%);
 }
 
-.page-header > p:last-child {
-  max-width: 45rem;
-  margin-bottom: 0;
-  color: #4c5d52;
+.wordmark {
+  font-size: 0.9375rem;
+  font-weight: 780;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+}
+
+.environment-badge {
+  border: 1px solid #a7cab6;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  color: var(--green-deep);
+  background: var(--green-soft);
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.02em;
+}
+
+.workspace {
+  width: min(70rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3.25rem 0 5rem;
+}
+
+.page-intro {
+  max-width: 43rem;
 }
 
 .eyebrow {
   margin: 0;
-  color: #126b42;
-  font-size: 0.8rem;
-  font-weight: 750;
-  letter-spacing: 0.12em;
+  color: var(--green);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
 }
 
-section {
-  margin-top: 1rem;
-  border: 1px solid #d8e0db;
-  border-radius: 0.85rem;
-  padding: 1.25rem;
-  background: #fff;
-  box-shadow: 0 0.25rem 1rem rgb(23 33 27 / 5%);
+.page-intro h1 {
+  max-width: 40rem;
+  margin: 0.6rem 0 0;
+  font-size: 2.25rem;
+  font-weight: 760;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
 }
 
-.section-heading {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
+.page-intro > p:last-child {
+  max-width: 40rem;
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+  font-size: 1rem;
 }
 
-.section-heading h2,
-.confirm-form h3 {
-  margin: 0;
-}
-
-.section-heading p {
-  margin: 0.25rem 0 0;
-  color: #5e6c63;
-}
-
-.form-grid {
+.flow-progress {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-
-.confirm-form {
-  margin-top: 1rem;
-  border-top: 1px solid #e1e7e3;
-  padding-top: 1rem;
-}
-
-.confirm-form h3,
-.full-width,
-.form-actions {
-  grid-column: 1 / -1;
-}
-
-label {
-  display: grid;
-  align-content: start;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  font-weight: 650;
-}
-
-input,
-select {
-  width: 100%;
-  border: 1px solid #b9c5bd;
-  border-radius: 0.45rem;
-  padding: 0.65rem 0.7rem;
-  color: #17211b;
-  background: #fff;
-}
-
-input:focus,
-select:focus,
-button:focus-visible {
-  outline: 3px solid rgb(18 107 66 / 20%);
-  outline-offset: 2px;
-}
-
-input:disabled,
-select:disabled {
-  background: #eef1ef;
-}
-
-.optional {
-  color: #6e7a72;
-  font-size: 0.78rem;
-  font-weight: 500;
-}
-
-.form-actions {
-  display: flex;
-  align-items: center;
-}
-
-.account-list {
-  display: grid;
-  gap: 0.5rem;
-  margin: 0;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 2.25rem 0 1.25rem;
   padding: 0;
   list-style: none;
 }
 
-.account-list li {
+.flow-progress li {
+  position: relative;
+  display: grid;
+  gap: 0.1rem;
+  border-top: 2px solid var(--divider);
+  padding-top: 0.75rem;
+  color: var(--soft-muted);
+}
+
+.flow-progress li::before {
+  position: absolute;
+  top: -0.375rem;
+  left: 0;
+  width: 0.625rem;
+  height: 0.625rem;
+  border: 2px solid var(--canvas);
+  border-radius: 50%;
+  background: var(--divider-strong);
+  content: "";
+}
+
+.flow-progress li.is-complete,
+.flow-progress li.is-current {
+  border-color: var(--green);
+  color: var(--ink);
+}
+
+.flow-progress li.is-complete::before,
+.flow-progress li.is-current::before {
+  background: var(--green);
+}
+
+.flow-progress span {
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.flow-progress small {
+  color: var(--soft-muted);
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+.commerce-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 19rem;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.flow-column {
+  display: grid;
+  gap: 1rem;
+}
+
+.task-step,
+.order-summary {
+  border: 1px solid var(--divider);
+  border-radius: 0.875rem;
+  background: var(--surface);
+}
+
+.task-step {
+  padding: 1.5rem;
+}
+
+.task-step-locked {
+  background: #f8faf9;
+}
+
+.step-heading {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border-radius: 0.5rem;
-  padding: 0.7rem;
-  background: #f2f7f4;
+  border-bottom: 1px solid var(--divider);
+  padding-bottom: 1rem;
 }
 
-code {
-  overflow-wrap: anywhere;
+.step-heading > div {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
 }
 
-.empty-state,
-.hint {
+.step-number {
+  display: inline-grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  place-items: center;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--green);
+  font-size: 0.8125rem;
+  font-weight: 800;
+}
+
+.step-heading h2 {
   margin: 0;
-  color: #6e7a72;
+  font-size: 1.125rem;
+  letter-spacing: -0.015em;
 }
 
-.error {
-  margin: 0.85rem 0 0;
-  border-left: 3px solid #b42318;
-  padding: 0.65rem 0.75rem;
-  color: #8b1c13;
-  background: #fff1f0;
+.step-meta {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 650;
+  text-align: right;
 }
 
-.resolution-details,
-.status-details {
+.checkout-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.5rem 0;
+}
+
+.checkout-action h3,
+.result-title-row h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.checkout-action p {
+  max-width: 31rem;
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.sandbox-data {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px dashed var(--divider-strong);
+  border-radius: 0.625rem;
+  padding: 0.875rem 1rem;
+  background: #fafcfb;
+}
+
+.sandbox-data > div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.sandbox-data span {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.sandbox-data code {
+  color: var(--ink);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.sandbox-data p {
+  margin: 0;
+  color: var(--soft-muted);
+  font-size: 0.75rem;
+  text-align: right;
+}
+
+.loading-state,
+.locked-copy,
+.supporting-copy {
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.loading-state {
+  margin: 1.5rem 0 0.5rem;
+}
+
+.locked-copy {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 1.25rem;
+}
+
+.locked-copy p {
+  margin: 0;
+}
+
+.lock-mark {
+  display: inline-grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--divider-strong);
+  border-radius: 50%;
+  color: var(--soft-muted);
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.result-stack {
+  display: grid;
+  gap: 0.875rem;
+  padding-top: 1.25rem;
+}
+
+.result-panel {
+  border: 1px solid #b8d4c4;
+  border-radius: 0.75rem;
+  padding: 1.125rem;
+  background: #f6fbf8;
+}
+
+.result-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.result-kicker {
+  margin: 0 0 0.2rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.status-badge {
+  display: inline-flex;
+  min-height: 1.65rem;
+  align-items: center;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.6875rem;
+  font-weight: 800;
+  letter-spacing: 0.025em;
+}
+
+.status-success {
+  color: var(--green-deep);
+  background: var(--green-soft);
+}
+
+.status-danger {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.status-pending {
+  color: #6b551b;
+  background: #fff8df;
+}
+
+.result-facts {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
+  gap: 1rem;
   margin: 1rem 0 0;
 }
 
-.resolution-details div,
-.status-details div {
-  border-radius: 0.5rem;
-  padding: 0.75rem;
-  background: #f2f7f4;
+.result-facts div {
+  border-top: 1px solid #d7e6dd;
+  padding-top: 0.75rem;
 }
 
 dt {
-  color: #5e6c63;
-  font-size: 0.78rem;
+  color: var(--soft-muted);
+  font-size: 0.72rem;
   font-weight: 700;
+  letter-spacing: 0.035em;
   text-transform: uppercase;
 }
 
 dd {
   margin: 0.2rem 0 0;
   overflow-wrap: anywhere;
+  font-size: 0.875rem;
   font-weight: 650;
 }
 
-.payout-result {
+.supporting-copy {
+  margin: 0.8rem 0 0;
+}
+
+.result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
   margin-top: 1rem;
-  border: 1px solid #a9cdb8;
-  border-radius: 0.65rem;
-  padding: 1rem;
-  background: #f3faf6;
 }
 
-.payout-result > p:first-child {
+.secondary-button,
+.button-link {
+  border-color: var(--divider-strong);
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.secondary-button:hover:not(:disabled),
+.button-link:hover {
+  border-color: var(--green);
+  color: var(--green-deep);
+  background: var(--green-soft);
+}
+
+.technical-details {
+  margin-top: 1rem;
+  border-top: 1px solid #d7e6dd;
+  padding-top: 0.75rem;
+}
+
+.technical-details summary {
+  width: fit-content;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.technical-details dl {
   display: grid;
-  gap: 0.25rem;
-  margin-top: 0;
+  gap: 0.65rem;
+  margin: 0.9rem 0 0;
 }
 
-@media (max-width: 40rem) {
-  main {
-    margin: 1.5rem auto;
+.technical-details dl div {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.settlement-workspace {
+  padding-top: 1.25rem;
+}
+
+.supplier-strip {
+  display: grid;
+  grid-template-columns: 1fr 1.25fr auto;
+  gap: 1rem;
+  border-bottom: 1px solid var(--divider);
+  padding-bottom: 1.15rem;
+}
+
+.supplier-strip div,
+.party-list div {
+  display: grid;
+  min-width: 0;
+}
+
+.supplier-strip span,
+.party-list span {
+  color: var(--soft-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.supplier-strip strong {
+  margin-top: 0.15rem;
+  overflow: hidden;
+  font-size: 0.875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rail-picker {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin: 1.25rem 0 0;
+  border: 0;
+  padding: 0;
+}
+
+.rail-picker legend {
+  grid-column: 1 / -1;
+  margin-bottom: 0.5rem;
+  padding: 0;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.rail-picker label {
+  display: flex;
+  min-height: 4rem;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid var(--divider);
+  border-radius: 0.625rem;
+  padding: 0.75rem;
+  cursor: pointer;
+}
+
+.rail-picker label:hover,
+.rail-picker label.is-selected {
+  border-color: var(--green);
+  background: var(--green-soft);
+}
+
+.rail-picker input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--green);
+}
+
+.rail-picker label > span {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.rail-picker strong {
+  font-size: 0.875rem;
+}
+
+.rail-picker small {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.rail-form,
+.bank-form {
+  margin-top: 1rem;
+}
+
+.resolve-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: end;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--ink);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+input:not([type="radio"]):not([type="checkbox"]),
+select {
+  min-height: 2.75rem;
+  width: 100%;
+  border: 1px solid var(--divider-strong);
+  border-radius: 0.375rem;
+  padding: 0.625rem 0.7rem;
+  color: var(--ink);
+  background: var(--surface);
+}
+
+input:not([type="radio"]):not([type="checkbox"]):disabled,
+select:disabled {
+  color: var(--soft-muted);
+  background: #eef2ef;
+}
+
+input:not([type="radio"]):not([type="checkbox"]):focus-visible,
+select:focus-visible,
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+.bank-review h3:focus-visible,
+.confirmation-check:has(input:focus-visible),
+.rail-picker label:has(input:focus-visible) {
+  outline: 3px solid #075b35;
+  outline-offset: 2px;
+}
+
+.field-note {
+  margin: 0.5rem 0 0;
+  color: var(--soft-muted);
+  font-size: 0.75rem;
+}
+
+.confirm-settlement,
+.bank-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.confirmation-check {
+  display: flex;
+  min-height: 2.75rem;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid var(--divider);
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  cursor: pointer;
+}
+
+.confirmation-check input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0;
+  accent-color: var(--green);
+}
+
+.resolution-preview {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  border: 1px solid #b8d4c4;
+  border-radius: 0.625rem;
+  padding: 0.9rem;
+  background: #f6fbf8;
+}
+
+.resolution-preview.is-unconfirmed {
+  border-color: var(--divider-strong);
+  background: #f7f9f8;
+}
+
+.resolution-preview.is-unconfirmed .resolution-mark {
+  color: var(--ink);
+  background: var(--divider-strong);
+}
+
+.resolution-mark {
+  display: grid;
+  width: 1.6rem;
+  height: 1.6rem;
+  place-items: center;
+  border-radius: 50%;
+  color: #ffffff;
+  background: var(--green);
+  font-size: 0.75rem;
+  font-weight: 900;
+}
+
+.resolution-preview > div:last-child {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.resolution-preview p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.resolution-preview strong {
+  font-size: 0.9375rem;
+}
+
+.resolution-preview span,
+.resolution-preview code {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.supplier-profile {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  border: 1px solid var(--divider);
+  border-radius: 0.625rem;
+  padding: 0.85rem;
+  background: #f8faf9;
+}
+
+.supplier-profile div,
+.read-only-field {
+  display: grid;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.supplier-profile span,
+.read-only-field span {
+  color: var(--soft-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.supplier-profile strong,
+.read-only-field strong {
+  overflow-wrap: anywhere;
+  font-size: 0.8125rem;
+}
+
+.read-only-field {
+  align-content: center;
+  min-height: 2.75rem;
+  border: 1px solid var(--divider);
+  border-radius: 0.375rem;
+  padding: 0.45rem 0.7rem;
+  background: #f8faf9;
+}
+
+.bank-review {
+  display: grid;
+  gap: 1rem;
+}
+
+.bank-review h3 {
+  margin: 0.2rem 0 0;
+  font-size: 1rem;
+}
+
+.review-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 0;
+}
+
+.review-facts div {
+  border-top: 1px solid var(--divider);
+  padding-top: 0.7rem;
+}
+
+.source-account-group {
+  display: grid;
+}
+
+.source-account-field {
+  margin-top: 0.15rem;
+}
+
+.inline-message {
+  margin: 0.9rem 0 0;
+  border: 1px solid currentColor;
+  border-radius: 0.5rem;
+  padding: 0.7rem 0.8rem;
+  font-size: 0.8125rem;
+}
+
+.message-error {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.message-warning {
+  color: var(--warning);
+  background: var(--warning-soft);
+}
+
+.inline-button {
+  display: inline;
+  min-height: 1.5rem;
+  border: 0;
+  padding: 0 0.15rem;
+  color: currentColor;
+  background: transparent;
+  font-size: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.inline-button:hover:not(:disabled) {
+  color: currentColor;
+  background: transparent;
+}
+
+.order-summary {
+  position: sticky;
+  top: 1rem;
+  padding: 1.25rem;
+}
+
+.order-summary-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.order-summary-heading h2 {
+  margin: 0.3rem 0 0;
+  font-size: 1rem;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+
+.quantity {
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.product-art {
+  position: relative;
+  height: 8.5rem;
+  margin: 1.1rem 0;
+  overflow: hidden;
+  border-radius: 0.625rem;
+  background: #e6eee9;
+}
+
+.package-body {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 50%;
+  width: 6.4rem;
+  height: 4.8rem;
+  transform: translateX(-50%);
+  border-radius: 0.35rem;
+  background: #bd755c;
+  box-shadow: inset 0 0.45rem 0 #96533f;
+}
+
+.package-tape {
+  position: absolute;
+  bottom: 1.25rem;
+  left: 50%;
+  width: 1.05rem;
+  height: 4.8rem;
+  transform: translateX(-50%);
+  background: #e7b585;
+}
+
+.package-label {
+  position: absolute;
+  bottom: 2.05rem;
+  left: 50%;
+  width: 2.75rem;
+  height: 1.25rem;
+  transform: translateX(-50%);
+  border: 0.25rem solid #f8f5ec;
+  background: var(--green);
+}
+
+.order-lines {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.order-lines div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.order-lines dt {
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.order-lines dd {
+  white-space: nowrap;
+}
+
+.order-lines .order-total {
+  border-top: 1px solid var(--divider);
+  padding-top: 0.75rem;
+}
+
+.party-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.15rem;
+  border-top: 1px solid var(--divider);
+  padding-top: 1rem;
+}
+
+.party-list strong {
+  margin-top: 0.1rem;
+  font-size: 0.8125rem;
+}
+
+.party-list small {
+  color: var(--muted);
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.order-state {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1rem;
+  border-top: 1px solid var(--divider);
+  padding-top: 1rem;
+}
+
+.order-state > span:last-child {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.sandbox-note {
+  margin: 1rem 0 0;
+  color: var(--soft-muted);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 52rem) {
+  .commerce-layout {
+    grid-template-columns: 1fr;
   }
 
-  .section-heading,
-  .account-list li {
+  .order-summary {
+    position: static;
+  }
+
+  .product-art {
+    height: 6.5rem;
+  }
+}
+
+@media (max-width: 38rem) {
+  .topbar {
+    min-height: 3.5rem;
+    padding: 0 1rem;
+  }
+
+  .workspace {
+    width: min(100% - 1rem, 36rem);
+    padding: 2rem 0 3rem;
+  }
+
+  .page-intro h1 {
+    font-size: 1.85rem;
+  }
+
+  .flow-progress {
+    grid-template-columns: 1fr;
+    gap: 0;
+    margin: 1.75rem 0 1rem;
+  }
+
+  .flow-progress li {
+    grid-template-columns: 1fr auto;
+    border-top: 0;
+    border-left: 2px solid var(--divider);
+    padding: 0.35rem 0 0.8rem 1rem;
+  }
+
+  .flow-progress li::before {
+    top: 0.45rem;
+    left: -0.375rem;
+  }
+
+  .task-step,
+  .order-summary {
+    border-radius: 0.7rem;
+    padding: 1rem;
+  }
+
+  .step-heading,
+  .checkout-action,
+  .sandbox-data,
+  .result-title-row {
     align-items: stretch;
     flex-direction: column;
   }
 
+  .step-meta,
+  .sandbox-data p {
+    text-align: left;
+  }
+
+  .checkout-action {
+    padding: 1.15rem 0;
+  }
+
+  .checkout-action button {
+    width: 100%;
+  }
+
+  .supplier-strip,
+  .supplier-profile,
+  .rail-picker,
   .form-grid,
-  .resolution-details,
-  .status-details {
+  .review-facts,
+  .result-facts {
     grid-template-columns: 1fr;
+  }
+
+  .resolve-row {
+    grid-template-columns: 1fr;
+  }
+
+  .resolve-row button,
+  .confirm-settlement > button,
+  .bank-form > button {
+    width: 100%;
+  }
+
+  .technical-details dl div {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/apps/example/src/styles.css
+++ b/apps/example/src/styles.css
@@ -5,7 +5,7 @@
     BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   line-height: 1.5;
-  text-rendering: optimizeLegibility;
+  text-rendering: optimizelegibility;
   --canvas: #f3f6f4;
   --surface: #ffffff;
   --ink: #17211b;
@@ -389,7 +389,7 @@ code {
   display: inline-flex;
   min-height: 1.65rem;
   align-items: center;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   border-radius: 999px;
   padding: 0.2rem 0.55rem;
   font-size: 0.6875rem;
@@ -792,7 +792,7 @@ summary:focus-visible,
 
 .inline-message {
   margin: 0.9rem 0 0;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   border-radius: 0.5rem;
   padding: 0.7rem 0.8rem;
   font-size: 0.8125rem;
@@ -813,7 +813,7 @@ summary:focus-visible,
   min-height: 1.5rem;
   border: 0;
   padding: 0 0.15rem;
-  color: currentColor;
+  color: currentcolor;
   background: transparent;
   font-size: inherit;
   text-decoration: underline;
@@ -821,7 +821,7 @@ summary:focus-visible,
 }
 
 .inline-button:hover:not(:disabled) {
-  color: currentColor;
+  color: currentcolor;
   background: transparent;
 }
 

--- a/packages/core/src/payouts-schemas.ts
+++ b/packages/core/src/payouts-schemas.ts
@@ -502,7 +502,7 @@ export const PayoutBankSchema = z
 export const PayoutAccountSchema = z
   .object({
     id: z.string(),
-    balanceInCents: z.number().int().optional(),
+    balanceInCents: z.number().int().nullish(),
     number: z.string().optional(),
     status: z.string().optional(),
     accountType: z.string().optional(),

--- a/packages/core/test/payouts.test.ts
+++ b/packages/core/test/payouts.test.ts
@@ -761,6 +761,29 @@ describe("WompiPayoutsClient", () => {
       expect(url).toContain("status=ACTIVE");
     });
 
+    it("accepts accounts whose balance is null", async () => {
+      const payouts = makeClient();
+
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          data: [
+            {
+              id: "account-without-balance",
+              balanceInCents: null,
+              status: "ACTIVE",
+              isMain: false,
+              consecutive: null,
+            },
+          ],
+        })
+      );
+
+      const [error, data] = await payouts.listAccounts();
+
+      expect(error).toBeNull();
+      expect(data![0]!.balanceInCents).toBeNull();
+    });
+
     it("returns the dispersion limits", async () => {
       const payouts = makeClient();
 


### PR DESCRIPTION
## Summary

- replace the payout playground with one ecommerce order that moves from hosted Checkout to supplier settlement
- make BRE-B the primary path and add a reviewed bank or digital-wallet alternative with saved supplier identity
- verify the exact approved checkout server-side before any payout and use deterministic one-order idempotency
- accept live payout accounts whose balance is null and prepare the core 3.2.1 patch changeset

## Live validation

- reproduced the null-balance account regression against the sandbox
- completed a Bancolombia sandbox payout through TOTAL_PAYMENT
- launched the server-signed COP 49,500 hosted Checkout through the ngrok origin
- final card submission is paused at Wompi legal consent pending explicit confirmation

## Checks

- CI=1 pnpm test: 223 core + 54 Convex + 21 example tests passed, 5 sandbox payout tests skipped
- CI=1 pnpm test:cov: 96.95% statements, 91.47% branches
- CI=1 pnpm build
- npm pack --dry-run --ignore-scripts --json
- targeted Biome and TypeScript checks
- final security, UX, and test reviews: no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end sandbox flow for hosted checkout, transaction verification, and supplier settlement.
  * Added support for settling suppliers through BRE-B keys or bank and wallet accounts.
  * Added persistent checkout progress, payout status refresh, and clear success or failure results.
  * Improved payout error messages and technical status details.

* **Bug Fixes**
  * Payout accounts with a `null` balance are now accepted.

* **Documentation**
  * Updated sandbox setup, checkout, settlement, accessibility, and design guidance.

* **Tests**
  * Added coverage for checkout validation, persistence, payout outcomes, and account handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the payout playground with an end-to-end hosted Checkout and supplier-settlement example.
- Adds server-side checkout signing and exact transaction verification.
- Adds BRE-B and bank or wallet settlement flows with deterministic idempotency.
- Accepts payout accounts whose reported balance is null.
- Adds settlement persistence, status presentation, tests, documentation, and design assets.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because an ambiguous payout response leaves settlement retries permanently stuck within the running server.

The retained attempt is the original resolved error rather than recoverable payout state, so retries never contact Wompi again and the UI never receives the payout ID required for status recovery.

apps/example/src/server/payouts.ts and apps/example/src/routes/index.tsx
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/example/src/server/payouts.ts | Adds verified, deterministic settlement creation, but ambiguous failures retain an error promise that prevents in-process recovery. |
| apps/example/src/routes/index.tsx | Implements the checkout-to-settlement interface and correctly treats null balances as unreported rather than insufficient. |
| apps/example/src/server/checkout.ts | Adds server-signed checkout creation and exact transaction verification before settlement. |
| packages/core/src/payouts-schemas.ts | Updates payout account parsing to accept null balances from live API responses. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Hosted Checkout] --> B[Verify approved transaction]
  B --> C[Choose supplier settlement rail]
  C --> D[Create deterministic payout request]
  D -->|Success| E[Persist payout ID]
  E --> F[Refresh payout status]
  D -->|Ambiguous failure| G[Retained resolved error promise]
  G -->|Retry in same process| G
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fexample%2Fsrc%2Fserver%2Fpayouts.ts%3A309-310%0A**Ambiguous%20retries%20remain%20stuck**%0A%0AWhen%20Wompi%20accepts%20a%20payout%20but%20its%20response%20ends%20in%20a%20timeout%2C%20network%20error%2C%20unparseable%20response%2C%20or%205xx%2C%20this%20returns%20the%20retained%20resolved%20error%20for%20every%20retry%20without%20invoking%20the%20payout%20request%20again.%20The%20UI%20therefore%20never%20receives%20the%20payout%20ID%20required%20for%20status%20recovery%2C%20leaving%20the%20supplier%20settlement%20stuck%20for%20the%20lifetime%20of%20the%20server%20process.%0A%0A&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fexample%2Fsrc%2Fserver%2Fpayouts.ts%3A309-310%0A**Ambiguous%20retries%20remain%20stuck**%0A%0AWhen%20Wompi%20accepts%20a%20payout%20but%20its%20response%20ends%20in%20a%20timeout%2C%20network%20error%2C%20unparseable%20response%2C%20or%205xx%2C%20this%20returns%20the%20retained%20resolved%20error%20for%20every%20retry%20without%20invoking%20the%20payout%20request%20again.%20The%20UI%20therefore%20never%20receives%20the%20payout%20ID%20required%20for%20status%20recovery%2C%20leaving%20the%20supplier%20settlement%20stuck%20for%20the%20lifetime%20of%20the%20server%20process.%0A%0A&repo=pulgueta%2Fwompi-node&pr=33&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/example/src/server/payouts.ts:309-310
**Ambiguous retries remain stuck**

When Wompi accepts a payout but its response ends in a timeout, network error, unparseable response, or 5xx, this returns the retained resolved error for every retry without invoking the payout request again. The UI therefore never receives the payout ID required for status recovery, leaving the supplier settlement stuck for the lifetime of the server process.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["style(example): lowercase css keyword va..."](https://github.com/pulgueta/wompi-node/commit/8bdd2a8ad13238f423927a6804fc04773ff5b23c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46592210)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->